### PR TITLE
Add Package Concierge and LA DWP rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -123,6 +123,9 @@
     "klm.com": {
         "password-rules": "minlength: 8; maxlength: 12;"
     },
+    "ladwp.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: digit; allowed: upper, lower;"
+    },
     "lowes.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },
@@ -143,6 +146,9 @@
     },
     "netgear.com": {
         "password-rules": "minlength: 6; maxlength: 128; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()];"
+    },
+    "packageconciergeadmin.com": {
+        "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },
     "paypal.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: digit, [!@#$%^&*()]; allowed: lower, upper;"


### PR DESCRIPTION
Package Concierge is a package pickup system that only allows numerical passwords of exactly 4 digits:
<img width="400" alt="PackageConcierge" src="https://user-images.githubusercontent.com/7576047/83465784-e4f38380-a429-11ea-838b-6cf74f257472.png">

LA Department of Water and Power requires passwords of 8-20 characters with >= 1 number:<img width="400" alt="LADWP error" src="https://user-images.githubusercontent.com/7576047/83466010-a4483a00-a42a-11ea-8858-aa78f793a680.png">


In both cases, Safari will recommend invalid passwords. These rules as tested on the [validation tool](https://developer.apple.com/password-rules/) generate passwords that are valid for both sites.