### PR TITLE
Add citi.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -41,6 +41,9 @@
     "chase.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower, upper; required: digit; required: [!#$%+/=@~]; max-consecutive: 2;"
     },
+    "citi.com": {
+        "password-rules": "minlength: 6; maxlength: 50; required: lower, upper; required: digit; max-consecutive: 2; allowed: [_!@$]"
+    },
     "claimlookup.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@#$%^&+=!];"
     },


### PR DESCRIPTION
Adding citi.com, validated with the web validation tool.

Password guidelines on Citi's website:

> - Different from your User ID
> - No spaces
> - From 6-50 characters
> - At least 1 letter
> - At least 1 number
> - No more than 2 consecutive identical characters
> - Approved special characters are _ ! @ $