### PR TITLE
Added secure-arborfcu rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -165,6 +165,9 @@
     "ruten.com.tw": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower, upper;"
     },
+    "secure-arborfcu.org": {
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
+    },
     "sephora.com": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },


### PR DESCRIPTION
Added secure-arborfcu.org rule to list.

Rules for site:
- Must be between 8 and 15 characters long
- Must contain one or more alphabetic characters
- Must contain at least one lower case character
- Must contain at least one upper case character
- Must contain one or more numeric characters
- Must contain one or more special characters
- These special characters are allowed: ! + & @ - . , : # $ % _ ? ~ ` ' ( ) [ ]
- Cannot contain a space or any special characters other than those listed above