### PR TITLE
add williams-sonoma inc sites with shared backends

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -289,6 +289,12 @@
         "wikimania.wikimedia.org"
     ],
     [
+        "williams-sonoma.com",
+        "markandgraham.com",
+        "potterybarn.com",
+        "westelm.com"
+    ],
+    [
         "wilson.com",
         "slugger.com",
         "atecsports.com",


### PR DESCRIPTION
Add Williams-Sonoma Inc. partner sites with shared backends using the same login credentials