### PR TITLE
Added Netflix's change URL and Microsoft related domains

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -4,5 +4,6 @@
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "twitter.com": "https://twitter.com/settings/password",
     "fnac.com": "https://secure.fnac.com/account/update-password",
+    "netflix.com": "https://www.netflix.com/password",
     "microsoft.com": "https://account.live.com/password/Change"
 }

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -86,7 +86,9 @@
     ],
     [
         "microsoft.com",
-        "live.com"
+        "live.com",
+        "office.com",
+        "microsoftonline.com"
     ],
     [
         "yahoo.com",


### PR DESCRIPTION
netflix.com/.well-known/change-password leads to error 404