### PR TITLE
Add shared credentials for Vail resort websites.

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -172,8 +172,22 @@
         "skype.com"
     ],
     [
+        "beavercreek.com",
+        "breckenridge.com",
+        "epicpass.com",
+        "keystoneresort.com",
+        "kirkwood.com",
+        "mountsunapee.com",
+        "northstarcalifornia.com",
+        "okemo.com",
+        "parkcitymountain.com",
+        "skicb.com",
+        "skiheavenly.com",
         "snow.com",
-        "skiheavenly.com"
+        "stevenspass.com",
+        "stowe.com",
+        "vail.com",
+        "whistlerblackcomb.com"
     ],
     [
         "livenation.com",


### PR DESCRIPTION
These websites are all owned by the same parent company, Vail Resorts. I tested my own credentials against all of these domains and was able to successfully log in to each of them.