### PR TITLE
Add banner aetna and aetna.com to shared credentials

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -4,6 +4,10 @@
         "icloud.com"
     ],
     [
+        "aetna.com",
+        "myplanportal.com"
+    ],
+    [
         "comcast.net",
         "xfinity.com"
     ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -5,7 +5,7 @@
     ],
     [
         "aetna.com",
-        "myplanportal.com"
+        "banneraetna.myplanportal.com"
     ],
     [
         "comcast.net",


### PR DESCRIPTION
whois aetna.com: 
> Registrant Email: domains@aetna.com
Registry Admin ID: 
Admin Name: Domain Administrator
Admin Organization: Aetna Life Insurance Company
Admin Street: 151 Farmington Ave, 


whois myplanportal.com:

>Registrant Email: domains@aetna.com
Registry Admin ID: 
Admin Name: Domain Administrator
Admin Organization: Aetna Life Insurance Company
Admin Street: 151 Farmington Ave, 

-- 
Same website credentials on either. 😁