### PR TITLE
Add nintendo.com change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -4,5 +4,6 @@
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "twitter.com": "https://twitter.com/settings/password",
     "fnac.com": "https://secure.fnac.com/account/update-password",
-    "microsoft.com": "https://account.live.com/password/Change"
+    "microsoft.com": "https://account.live.com/password/Change",
+    "nintendo.com": "https://accounts.nintendo.com/password/edit"
 }


### PR DESCRIPTION
I tested direct access to the URL logged in, or not, without issues.