### PR TITLE
Remove twitter.com change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -2,7 +2,6 @@
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
     "twitch.tv": "https://www.twitch.tv/settings/security",
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
-    "twitter.com": "https://twitter.com/settings/password",
     "fnac.com": "https://secure.fnac.com/account/update-password",
     "microsoft.com": "https://account.live.com/password/Change"
 }


### PR DESCRIPTION
Twitter.com supports `.well-known/change-password`. You can try it: https://twitter.com/.well-known/change-password

As explained in the Project's README, those websites should not be included in this file.

Also remove the duplicated line for fnac.com.