### PR TITLE
Remove Amazon.co.jp from websites-with-shared-credential-backends.json

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -102,7 +102,6 @@
         "amazon.de",
         "amazon.in",
         "amazon.it",
-        "amazon.co.jp",
         "amazon.com.mx",
         "amazon.nl",
         "amazon.es",


### PR DESCRIPTION
Amazon.co.jp is on a different platform than Amazon.com and the rest of
Amazon sites and thus requires a different login.

https://www.amazon.co.jp/b?node=5835715051