### PR TITLE
add stackexchange sites with shared backends

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -176,6 +176,13 @@
         "skiheavenly.com"
     ],
     [
+        "stackoverflow.com",
+        "askubuntu.com",
+        "serverfault.com",
+        "stackexchange.com",
+        "superuser.com"
+    ],
+    [
         "livenation.com",
         "ticketmaster.com"
     ],


### PR DESCRIPTION
From what I could find these are all the main websites that are part of the stackexchange network that have their own second level domain.