### PR TITLE
Add key.harvard.edu to password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -141,6 +141,9 @@
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"
     },
+    "myaccess.dmdc.osd.mil": {
+        "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@_#!&$`%*+()./,;~:{}|?>=<^[]'-];"
+    },
     "myhealthrecord.com": {
         "password-rules": "minlength: 8; maxlength: 20; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.!$*=];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -102,6 +102,9 @@
     "girlscouts.org": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$#!];"
     },
+    "key.harvard.edu": {
+        "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@_#!&$`%*+()./,;~:{}|?>=<^[]'-];"
+    },
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -103,7 +103,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$#!];"
     },
     "key.harvard.edu": {
-        "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@_#!&$`%*+()./,;~:{}|?>=<^[]'-];"
+        "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [@_#!&$`%*+()./,;~:{}|?>=<^['-]];"
     },
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -144,9 +144,6 @@
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"
     },
-    "myaccess.dmdc.osd.mil": {
-        "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@_#!&$`%*+()./,;~:{}|?>=<^[]'-];"
-    },
     "myhealthrecord.com": {
         "password-rules": "minlength: 8; maxlength: 20; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.!$*=];"
     },


### PR DESCRIPTION
This commit adds key.harvard.edu to the password ruleset.  Verified with the password change utility.
