### PR TITLE
Add all eBay sites

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -192,8 +192,28 @@
         "luxilon.com"
     ],
     [
+        "ebay.at",
+        "ebay.be",
+        "ebay.ca",
+        "ebay.ch",
+        "ebay.cn",
+        "ebay.co.th",
+        "ebay.co.uk",
         "ebay.com",
-        "ebay.co.uk"
+        "ebay.com.au",
+        "ebay.com.hk",
+        "ebay.com.my",
+        "ebay.com.sg",
+        "ebay.com.tw",
+        "ebay.de",
+        "ebay.es",
+        "ebay.fr",
+        "ebay.ie",
+        "ebay.it",
+        "ebay.nl",
+        "ebay.ph",
+        "ebay.pl",
+        "ebay.vn"
     ],
     [
         "lookmark.io",


### PR DESCRIPTION
All the local eBay sites use different TLDs. You can check the SSL certificates to verify this.