### PR TITLE
Quirks for vetsfirstchoice.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -202,7 +202,7 @@
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },
     "vetsfirstchoice.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [?!@$%^+=&]"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [?!@$%^+=&];"
     },
     "visa.com": {
         "password-rules": "minlength: 6; maxlength: 32;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -201,6 +201,9 @@
     "vanguard.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },
+    "vetsfirstchoice.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [?!@$%^+=&]"
+    },
     "visa.com": {
         "password-rules": "minlength: 6; maxlength: 32;"
     },


### PR DESCRIPTION
Add quirks for vetsfirstchoice.com. Notably, doesn't allow dashes.

Additional info: domain is a top-level domain for a pharmacy PAAS run by Covetrus. Their customers have their own subdomains (e.g.: springfieldvet.vetsfirstchoice.com) which are the actual websites, the top-level domain just forwards to Covetrus' website.

<img width="365" alt="vetsfirstchoice-pass-dialog" src="https://user-images.githubusercontent.com/1447034/83934343-4004dd80-a77e-11ea-9f0b-5dbbef00c8fd.png">