### PR TITLE
Remove duplicate required: digit; for vanguard

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -199,7 +199,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-]; required: [!@#$%^&*()+];"
     },
     "vanguard.com": {
-        "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
+        "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit;"
     },
     "visa.com": {
         "password-rules": "minlength: 6; maxlength: 32;"


### PR DESCRIPTION
I noticed there were two `required: digit;` and thought it was a typo. 