### PR TITLE
Add rules for bankofamerica.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -20,6 +20,9 @@
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"
     },
+    "bankofamerica.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [@#*()+={}/?~;,.-_];"
+    },
     "beglammed.com": {
         "password-rules": "minlength: 6;"
     },


### PR DESCRIPTION
Screenshot of BofA's website listing passcode rules:

![image](https://user-images.githubusercontent.com/137214/83936423-857ed600-a791-11ea-9b3c-defb56377082.png)

Technically special characters aren't subject to the "more than 3 times in a row" rule, but I don't think the syntax supports this case 🙂