### PR TITLE
Add Sony Entertainment shared credentials backend

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -217,5 +217,9 @@
     [
         "lookmark.io",
         "lookmark.link"
+    ],
+    [
+        "playstation.com",
+        "id.sonyentertainmentnetwork.com"
     ]
 ]


### PR DESCRIPTION
Fixes apple/password-manager-resources#75