### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,3 +3,4 @@
 ### Checklist
 - [ ] The PR isn't documenting something that would be common practice among password managers (e.g. minimal length of 6)
 - [ ] The top-level json objects are sorted alphabetically 
+- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
+
+### Checklist
+- [ ] The PR isn't documenting something that would be common practice among password managers (e.g. minimal length of 6)
+- [ ] The top-level json objects are sorted alphabetically 


### PR DESCRIPTION
This might help reduce a number of repeating comments on PRs, such as [#47](https://github.com/apple/password-manager-resources/pull/47#issuecomment-639885595) & [#66](https://github.com/apple/password-manager-resources/pull/66#discussion_r436241480) and also remind contributors to make sure their contributions are in the correct sort order.