### PR TITLE
Add acrons.com Password change URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -1,5 +1,6 @@
 {
     "500px.com": "https://web.500px.com/settings/account/security",
+    "acorns.com" "https://app.acorns.com/settings/change-password,
     "amctheatres.com": "https://www.amctheatres.com/amcstubs/account",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -1,6 +1,6 @@
 {
     "500px.com": "https://web.500px.com/settings/account/security",
-    "acorns.com" "https://app.acorns.com/settings/change-password,
+    "acorns.com": "https://app.acorns.com/settings/change-password",
     "amctheatres.com": "https://www.amctheatres.com/amcstubs/account",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",


### PR DESCRIPTION
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [X] The top-level JSON objects are sorted alphabetically 
- [X] There is no Well-Known URL for Changing Passwords (https://example.com/.well-known/change-password)