### PR TITLE
Update Telekom password rule + adding Telekom shared credential backends

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -135,6 +135,9 @@
     "lowes.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },
+    "lufthansa.com": {
+        "password-rules": "required: lower; required: upper; required: digit; required: [!"#$%&()*+,./:;<>?@\_]; minlength: 8; maxlength: 32;"
+    },
     "macys.com": {
         "password-rules": "minlength: 7; maxlength: 16; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*+`(){}[:;\"'<>?]];"
     },

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -218,4 +218,8 @@
         "lookmark.io",
         "lookmark.link"
     ]
+    [
+        "telekom-dienste.de",
+        "accounts.login.idm.telekom.com"
+    ]
 ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -222,4 +222,8 @@
         "telekom-dienste.de",
         "accounts.login.idm.telekom.com"
     ]
+    [
+        "lufthansa.com",
+        "miles-and-more.com"
+    ]
 ]


### PR DESCRIPTION
Hi,

as shown in the screenshot below from their [registration site](https://meinkonto.telekom-dienste.de/telekom/email/registration/registration.xhtml) their requirements go beyond 8-16 characters:

![Bildschirmfoto 2020-06-06 um 15 10 08](https://user-images.githubusercontent.com/27491477/83945553-bd2a6400-a80b-11ea-85f4-e5dcc767bcc4.png)

Moreover, while [telekom-dienste.de](telekom-dienste.de) is the domain on which you can register a new account, logging into their various services happens on [accounts.login.idm.telekom.com](accounts.login.idm.telekom.com). For example, if you go to their [customer portal](https://www.telekom.de/kundencenter/startseite) you'll be redirected to [accounts.login.idm.telekom.com](accounts.login.idm.telekom.com).
