### PR TITLE
Add rules for zoom.us

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -16,5 +16,6 @@
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
     "twitch.tv": "https://www.twitch.tv/settings/security",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",
-    "yahoo.com": "https://login.yahoo.com/account/change-password"
+    "yahoo.com": "https://login.yahoo.com/account/change-password",
+    "zoom.us": "https://zoom.us/profile#pwd-form"
 }

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -218,5 +218,8 @@
     },
     "xfinity.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; required: digit;"
+    },
+    "zoom.us": {
+        "password-rules": "required: lower; required: upper; required: digit; max-consecutive: 6; minlength: 8; maxlength: 32;"
     }
 }

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -220,6 +220,6 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; required: digit;"
     },
     "zoom.us": {
-        "password-rules": "required: lower; required: upper; required: digit; max-consecutive: 6; minlength: 8; maxlength: 32;"
+        "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; max-consecutive: 6;"
     }
 }


### PR DESCRIPTION
According to https://support.zoom.us/hc/en-us/articles/115005166483-Managing-your-password#h_6d872dd8-6215-43b2-9ddf-8d5c966725d0

- [x] The PR isn't documenting something that would be common practice among password managers (e.g. minimal length of 6)
- [x] The top-level json objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (https://example.com/.well-known/change-password)