### PR TITLE
Updated with Playstation.com in websites-with-shared-credential-backends

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -217,5 +217,9 @@
     [
         "lookmark.io",
         "lookmark.link"
-    ]
+    ],
+    [
+        "id.sonyentertainmentnetwork.com",
+        "playstation.com"
+    ],
 ]


### PR DESCRIPTION
- Includes playstation.com -> id.sonyentertainmentnetwork.com password share
- Resolves #75