### PR TITLE
Cathay Pacific shared credential backend

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -217,5 +217,9 @@
     [
         "lookmark.io",
         "lookmark.link"
+    ],
+    [
+        "asiamiles.com",
+        "cathaypacific.com"
     ]
 ]


### PR DESCRIPTION
[`asiamiles.com`](asiamiles.com) and [`cathaypacific.com`](cathaypacific.com) have a shared credential backend.

On Cathay Pacific's website [[1]](https://www.cathaypacific.com/cx/en_GB/site-help/sign-in.html):
"If you are Marco Polo Club or Asia Miles member, you can use your membership number/username and password to access your account page."

Asia Miles is a wholly owned subsidiary of Cathay Pacific. [[2]](https://www.asiamiles.com/content/dam/am-web/pdf/en/Asia%20Miles%20Backgrounder_EN%20(September%202019).pdf)

Both domains have the same Registrant information in WHOIS data. [[3]](https://who.is/whois/cathaypacific.com)[[4]](https://who.is/whois/asiamiles.com)