### PR TITLE
Add NYTimes Password Change URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -13,6 +13,7 @@
     "myaccount.ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "news.ycombinator.com": "https://news.ycombinator.com/changepw",
     "nintendo.com": "https://accounts.nintendo.com/password/edit",
+    "nytimes.com": "https://myaccount.nytimes.com/seg/profile",
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
     "twitch.tv": "https://www.twitch.tv/settings/security",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [X] The top-level JSON objects are sorted alphabetically 
- [X] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pull) for the same update.