### PR TITLE
Updating Telekom + adding Lufthansa password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -136,7 +136,7 @@
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },
     "lufthansa.com": {
-        "password-rules": "required: lower; required: upper; required: digit; required: [!"#$%&()*+,./:;<>?@\_]; minlength: 8; maxlength: 32;"
+        "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
     "macys.com": {
         "password-rules": "minlength: 7; maxlength: 16; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*+`(){}[:;\"'<>?]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -135,6 +135,9 @@
     "lowes.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },
+    "lufthansa.com": {
+        "password-rules": "required: lower; required: upper; required: digit; required: [!"#$%&()*+,./:;<>?@\_]; minlength: 8; maxlength: 32;"
+    },
     "macys.com": {
         "password-rules": "minlength: 7; maxlength: 16; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*+`(){}[:;\"'<>?]];"
     },
@@ -196,7 +199,7 @@
         "password-rules": "minlength: 8; maxlength: 16;"
     },
     "telekom-dienste.de": {
-        "password-rules": "minlength: 8; maxlength: 16;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%&()*+,./<=>?@_{|}~];"
     },
     "ubisoft.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-]; required: [!@#$%^&*()+];"


### PR DESCRIPTION
Telekom: Added additional requirements as shown in the screenshot below

![Bildschirmfoto 2020-06-06 um 15 10 08](https://user-images.githubusercontent.com/27491477/83947435-22d01d80-a817-11ea-9d46-af7218badca4.png)

Lufthansa: Add password rule following their guidelines and after manually checking that their form doesn't accept password longer than 32 characters

![Bildschirmfoto 2020-06-06 um 16 26 26](https://user-images.githubusercontent.com/27491477/83947456-4dba7180-a817-11ea-92c3-691bec9328f4.png)
