### PR TITLE
Add autify.com password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -18,7 +18,7 @@
         "password-rules": "minlength: 6; maxlength: 19;"
     },
     "autify.com": {
-        "password-rules": "required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]]; minlength: 8;"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -17,6 +17,9 @@
     "artscyclery.com": {
         "password-rules": "minlength: 6; maxlength: 19;"
     },
+    "autify.com": {
+        "password-rules": "required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]]; minlength: 8;"
+    },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"
     },


### PR DESCRIPTION
I'm working for https://autify.com (@autifyhq) and I know the password rule we're using, so I'd like to add them here.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pull) for the same update.
