### PR TITLE
Change password URL for gmx.net

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -7,6 +7,7 @@
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "fnac.com": "https://secure.fnac.com/account/update-password",
     "geocaching.com": "https://www.geocaching.com/account/settings/changepassword",
+    "gmx.net": "https://account.gmx.net/ciss/security/edit/passwordChange",
     "gov.br": "https://acesso.gov.br/area-cidadao/#/alterarSenha",
     "impots.gouv.fr": "https://cfspart.impots.gouv.fr/monprofil-webapp/GererMonProfil",
     "linode.com": "https://cloud.linode.com/profile/auth",


### PR DESCRIPTION
gmx.net is a well-known email provider in Germany and is a subsidiary of United Internet AG.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pull) for the same update.
