### PR TITLE
Added disneyplus.com change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -3,6 +3,7 @@
     "amctheatres.com": "https://www.amctheatres.com/amcstubs/account",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",
+    "disneyplus.com": "https://www.disneyplus.com/account/change-password",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "fnac.com": "https://secure.fnac.com/account/update-password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pull) for the same update.
