### PR TITLE
Added change password URL for cloudflare.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -3,6 +3,7 @@
     "amctheatres.com": "https://www.amctheatres.com/amcstubs/account",
     "atlassian.com": "https://id.atlassian.com/manage-profile/security",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
+    "cloudflare.com": "https://dash.cloudflare.com/profile/authentication",
     "consumidor.gov.br": "https://www.consumidor.gov.br/pages/usuario/editar",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",
     "disneyplus.com": "https://www.disneyplus.com/account/change-password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
