### PR TITLE
add shared backend websites for America's Test Kitchen

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -248,11 +248,5 @@
         "cooksillustrated.com",
         "cookscountry.com",
         "onlinecookingschool.com"
-    ],
-    [
-        "americastestkitchen.com",
-        "cooksillustrated.com",
-        "cookscountry.com",
-        "onlinecookingschool.com"
     ]
 ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -242,5 +242,17 @@
     [
         "asiamiles.com",
         "cathaypacific.com"
+    ],
+    [
+        "americastestkitchen.com",
+        "cooksillustrated.com",
+        "cookscountry.com",
+        "onlinecookingschool.com"
+    ],
+    [
+        "americastestkitchen.com",
+        "cooksillustrated.com",
+        "cookscountry.com",
+        "onlinecookingschool.com"
     ]
 ]


### PR DESCRIPTION
America's Test Kitchen has 4 different recipe websites (with different target audiences), but all the sites share a login for saving recipes. 

I added the four domains to the list of websites with shared credential backends.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
