### PR TITLE
Added change password URL for paypal.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -20,6 +20,7 @@
     "nintendo.com": "https://accounts.nintendo.com/password/edit",
     "nytimes.com": "https://myaccount.nytimes.com/seg/profile",
     "patreon.com": "https://www.patreon.com/settings/profile",
+    "paypal.com": "https://www.paypal.com/myaccount/security/password/change",
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
     "twitch.tv": "https://www.twitch.tv/settings/security",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",


### PR DESCRIPTION
This is a highly sensitive service and among the most phished websites in the world. Please tripple check the URL :)

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
