### PR TITLE
Added change password URL for dropbox.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -7,6 +7,7 @@
     "consumidor.gov.br": "https://www.consumidor.gov.br/pages/usuario/editar",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",
     "disneyplus.com": "https://www.disneyplus.com/account/change-password",
+    "dropbox.com": "https://www.dropbox.com/account/security",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "fnac.com": "https://secure.fnac.com/account/update-password",


### PR DESCRIPTION
Sadly, this link only leads to the account security page. There is no direct link to change the password.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
