### PR TITLE
Added change password URL for teamviewer.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -26,6 +26,7 @@
     "paypal.com": "https://www.paypal.com/myaccount/security/password/change",
     "plex.tv": "https://app.plex.tv/desktop#!/account",
     "reelgood.com": "https://reelgood.com/account",
+    "teamviewer.com": "https://login.teamviewer.com/nav/profile/change-password",
     "thenounproject.com": "https://thenounproject.com/accounts/password/change/",
     "thetrainline.com": "https://www.thetrainline.com/my-account/change-password",
     "thetvdb.com": "https://www.thetvdb.com/dashboard/account/changepass",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
