### PR TITLE
update PR template with def of shared backend

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 - [ ] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
 
 #### for websites-with-shared-credential-backends.json
-- [ ] The new group has login pages on each of the included domains. For example, firstcompany-com/login and secondcompany-com/login share the same backend, despite the different base domains. 
+- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don’t associate google.com.li to google.com, because google.com.li redirects to accounts.google.com for authentication.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,6 @@
 - [ ] The top-level JSON objects are sorted alphabetically 
 - [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
 - [ ] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
+
+#### for websites-with-shared-credential-backends.json
+- [ ] The new group has login pages on each of the included domains. For example, firstcompany-com/login and secondcompany-com/login share the same backend, despite the different base domains. 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,10 @@
 ### Checklist
 - [ ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
 - [ ] The top-level JSON objects are sorted alphabetically 
-- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
 - [ ] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
 
 #### for websites-with-shared-credential-backends.json
 - [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don’t associate google.com.li to google.com, because google.com.li redirects to accounts.google.com for authentication.)
+
+#### for change-password-URLs.json
+- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ An implementation of a parser for the Password Rules language that's written in 
 
 The file [`quirks/websites-with-shared-credential-backends.json`](quirks/websites-with-shared-credential-backends.json) contains a list of groups of websites that are known to share the same credential backend. This can be used to offer contextually relevant accounts to users on website A, even if credentials were previously saved for website B.
 
+In other words, a qualifying group serves login pages on each of the included domains. Those login pages accept accounts from the others. For example, `firstcompany.website/login` and `secondcompany.website/login` share the same backend (e.g., usernames, passwords, profiles), despite the different base domains.
+
+We don’t associate `google.com.li` to `google.com`, because `google.com.li` redirects to `accounts.google.com` for authentication.
+
 This list should not be used as part of any user experience that releases user credentials to a website without the user's explicit review and consent. In general, saved credentials should only be suggested to users with site-bound scoping. This list is appropriate for allowing a credential saved for website A to appear on website B if the website the credential was saved for is clearly stated.
 
 There are existing proposals to allow different domains to declare an affiliation with each other, which could be a way for websites to solve this problem themselves, given browser and password manager adoption of such a proposal. Until and perhaps beyond then, it is useful to have these groupings of websites to make password filling suggestions more useful.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,9 @@ An implementation of a parser for the Password Rules language that's written in 
 
 ### Websites with Shared Credential Backends
 
-The file [`quirks/websites-with-shared-credential-backends.json`](quirks/websites-with-shared-credential-backends.json) contains a list of groups of websites that are known to share the same credential backend. This can be used to offer contextually relevant accounts to users on website A, even if credentials were previously saved for website B.
+The file quirks/websites-with-shared-credential-backends.json contains a list of groups of websites that share the same credential backend and serve pages where users can sign in, accepting accounts from the others. For example, adding first.website and second.website means that first.website and second.website each serve a page (e.g. first.website/login and second.website/login) where the same accounts are valid for signing in, despite the different domains. It wouldn’t be appropriate to associate google.com.il to google.com because google.com.il redirects to accounts.google.com for sign-in, and google.com.il never serves a login page.
 
-In other words, a qualifying group serves login pages on each of the included domains. Those login pages accept accounts from the others. For example, `firstcompany.website/login` and `secondcompany.website/login` share the same backend (e.g., usernames, passwords, profiles), despite the different base domains.
-
-We don’t associate `google.com.li` to `google.com`, because `google.com.li` redirects to `accounts.google.com` for authentication.
+This data can be used by password managers to offer contextually relevant accounts to users on first.website, even if credentials were previously saved for second.website. 
 
 This list should not be used as part of any user experience that releases user credentials to a website without the user's explicit review and consent. In general, saved credentials should only be suggested to users with site-bound scoping. This list is appropriate for allowing a credential saved for website A to appear on website B if the website the credential was saved for is clearly stated.
 


### PR DESCRIPTION
based on the discussion in #58 I propose revising the pull request template.

This version clarifies when a group of domains is necessary.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
