### PR TITLE
Update udel.edu change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -52,7 +52,7 @@
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
     "twilio.com": "https://www.twilio.com/console/user/settings",
     "twitch.tv": "https://www.twitch.tv/settings/security",
-    "udel.edu": "https://udapps.nss.udel.edu/passwordReset/selfservice",
+    "udel.edu": "https://udapps.nss.udel.edu/myUDsettings/password",
     "umsystem.edu": "https://password.umsystem.edu/reset/",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",
     "yahoo.com": "https://login.yahoo.com/account/change-password",


### PR DESCRIPTION
The old URL pointed to a reset password URL - change password URL is: https://udapps.nss.udel.edu/myUDsettings/password

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
