### PR TITLE
Add grubhub.com's Change Password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -18,6 +18,7 @@
     "gmx.net": "https://account.gmx.net/ciss/security/edit/passwordChange",
     "gog.com": "https://www.gog.com/account/settings/security",
     "gov.br": "https://acesso.gov.br/area-cidadao/#/alterarSenha",
+    "grubhub.com": "https://www.grubhub.com/account/profile",
     "impots.gouv.fr": "https://cfspart.impots.gouv.fr/monprofil-webapp/GererMonProfil",
     "key.harvard.edu": "https://key.harvard.edu/manage-account/change-password",
     "linkedin.com": "https://www.linkedin.com/psettings/change-password",


### PR DESCRIPTION
If you visit this URL while not signed in, you are taken to a login page
that redirects to Change Password page after successful authentication.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don’t associate google.com.li to google.com, because google.com.li redirects to accounts.google.com for authentication.)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)