### PR TITLE
Add crunchyroll.com's Change Password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -9,6 +9,7 @@
     "censys.io": "https://censys.io/account",
     "cloudflare.com": "https://dash.cloudflare.com/profile/authentication",
     "consumidor.gov.br": "https://www.consumidor.gov.br/pages/usuario/editar",
+    "crunchyroll.com": "https://www.crunchyroll.com/acct",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",
     "disneyplus.com": "https://www.disneyplus.com/account/change-password",
     "dropbox.com": "https://www.dropbox.com/account/security",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don’t associate google.com.li to google.com, because google.com.li redirects to accounts.google.com for authentication.)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)