### PR TITLE
Check duplicates in the shared backend list

### DIFF
--- a/.github/workflows/lint-scripts/websites-shared-credentials-duplicates.rb
+++ b/.github/workflows/lint-scripts/websites-shared-credentials-duplicates.rb
@@ -1,0 +1,12 @@
+require 'json'
+require 'set'
+
+shared_websites = JSON.parse(File.read('quirks/websites-with-shared-credential-backends.json'))
+
+seen_domains = Set.new
+shared_websites.flatten.each do |domain|
+  STDERR.puts "The domain '#{domain}' appears more than once!" if seen_domains.include?(domain)
+  seen_domains << domain
+end
+
+exit(1) if seen_domains.count != shared_websites.flatten.count

--- a/.github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
+++ b/.github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'set'
 
 shared_websites = JSON.parse(File.read('quirks/websites-with-shared-credential-backends.json'))
 
@@ -12,3 +13,11 @@ unless shared_websites == shared_websites_sorted
   STDERR.puts "The JSON in 'quirks/websites-with-shared-credential-backends.json' isn't sorted!"
   exit(1) 
 end
+
+seen_domains = Set.new
+shared_websites.flatten.each do |domain|
+  STDERR.puts "The domain '#{domain}' appears more than once!" if seen_domains.include?(domain)
+  seen_domains << domain
+end
+
+exit(1) if seen_domains.count != shared_websites.flatten.count

--- a/.github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
+++ b/.github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'set'
 
 shared_websites = JSON.parse(File.read('quirks/websites-with-shared-credential-backends.json'))
 
@@ -13,11 +12,3 @@ unless shared_websites == shared_websites_sorted
   STDERR.puts "The JSON in 'quirks/websites-with-shared-credential-backends.json' isn't sorted!"
   exit(1) 
 end
-
-seen_domains = Set.new
-shared_websites.flatten.each do |domain|
-  STDERR.puts "The domain '#{domain}' appears more than once!" if seen_domains.include?(domain)
-  seen_domains << domain
-end
-
-exit(1) if seen_domains.count != shared_websites.flatten.count

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,3 +38,5 @@ jobs:
         ruby-version: 2.6
     - name: Lint Sort Order
       run: ruby .github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
+    - name: Lint Duplicates
+      run: ruby .github/workflows/lint-scripts/websites-shared-credentials-duplicates.rb

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -168,16 +168,6 @@
         "kp.org"
     ],
     [
-        "live.com",
-        "skype.com"
-    ],
-    [
-        "live.com",
-        "microsoft.com",
-        "microsoftonline.com",
-        "office.com"
-    ],
-    [
         "lookmark.io",
         "lookmark.link"
     ],
@@ -191,6 +181,13 @@
         "ritzcarlton.com",
         "spg.com",
         "starwoodhotels.com"
+    ],
+    [
+        "microsoft.com",
+        "live.com",
+        "microsoftonline.com",
+        "office.com",
+        "skype.com"
     ],
     [
         "nokia.com",


### PR DESCRIPTION
This PR verifies that `websites-with-shared-credential-backends.json` doesn't contain duplicate domains.

