### PR TITLE
Add password rules for ecompanystore.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -92,6 +92,9 @@
     "dowjones.com": {
         "password-rules": "maxlength: 15;"
     },
+    "ecompanystore.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%*+.=@^_]; max-consecutive: 2;"
+    },
     "eddservices.edd.ca.gov": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; required: [!@#$%^&*()];"
     },


### PR DESCRIPTION
As flagged by Taylor Swift: https://twitter.com/swiftonsecurity/status/1270082231877263360?s=21

This website doesn't allow a `?` to be the first character, so I omit it from the special characters set to ensure it's never used as the first character. A future enhancement to the passwordRules language may accommodate this constraint better.

<img width="839" alt="Screen Shot 2020-06-08 at 1 24 22 PM" src="https://user-images.githubusercontent.com/234616/84076872-5fbd2100-a98b-11ea-84fb-a9329e8f44fb.png">

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
