### PR TITLE
Add password rules for prepaid.bankofamerica.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -29,9 +29,6 @@
     "bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [@#*()+={}/?~;,.-_];"
     },
-     "prepaid.bankofamerica.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: upper; required: lower; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
-    },
     "bhphotovideo.com": {
         "password-rules": "maxlength: 15;"
     },
@@ -197,6 +194,9 @@
     },
     "pixnet.cc": {
         "password-rules": "minlength: 4; maxlength: 16; allowed: lower, upper;"
+    },
+      "prepaid.bankofamerica.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: upper; required: lower; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
     },
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -29,6 +29,9 @@
     "bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [@#*()+={}/?~;,.-_];"
     },
+     "prepaid.bankofamerica.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: upper; required: lower; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
+    },
     "bhphotovideo.com": {
         "password-rules": "maxlength: 15;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -195,7 +195,7 @@
     "pixnet.cc": {
         "password-rules": "minlength: 4; maxlength: 16; allowed: lower, upper;"
     },
-      "prepaid.bankofamerica.com": {
+    "prepaid.bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: upper; required: lower; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
     },
     "propelfuels.com": {


### PR DESCRIPTION
Slightly different from BankofAmerica.com [see screenshot] - validated by going to prepaid.bankofamerica.com/[subDirectory]/PasswordChange and testing from password rule generator.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
