### PR TITLE
Add Disney+ to Disney/go.com shared backend

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -47,7 +47,8 @@
     [
         "shopdisney.com",
         "disneystore.com",
-        "go.com"
+        "go.com",
+        "disneyplus.com"
     ],
     [
         "gogoair.com",


### PR DESCRIPTION
Add Disney+

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

`whois disneyplus.com`
![image](https://user-images.githubusercontent.com/7369280/84087379-d31c5e00-a99e-11ea-9b19-fa1bd20cbd6f.png)
`whois go.com`
![image](https://user-images.githubusercontent.com/7369280/84087448-f47d4a00-a99e-11ea-9ba9-3532004ad1d9.png)


#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
