### PR TITLE
Adds Call of Duty password rules and change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -6,6 +6,7 @@
     "atlassian.com": "https://id.atlassian.com/manage-profile/security",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
+    "callofduty.com": "https://profile.callofduty.com/cod/prefs",
     "censys.io": "https://censys.io/account",
     "cloudflare.com": "https://dash.cloudflare.com/profile/authentication",
     "consumidor.gov.br": "https://www.consumidor.gov.br/pages/usuario/editar",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -41,6 +41,9 @@
     "brighthorizons.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },
+    "callofduty.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; max-consecutive: 2;"
+    },
     "cb2.com": {
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)

### Evidence
<img width="1400" alt="image" src="https://user-images.githubusercontent.com/6236080/84089846-5619d480-a9f0-11ea-841e-41eacd20dadb.png">
