### PR TITLE
add change password url for 1800contacts

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -1,4 +1,5 @@
 {
+    "1800contacts.com": "https://www.1800contacts.com/account/settings",
     "500px.com": "https://web.500px.com/settings/account/security",
     "acorns.com": "https://app.acorns.com/settings/change-password",
     "alliantcreditunion.com": "https://www.alliantcreditunion.com/OnlineBanking/Settings/AccessAndSecurity/ChangePassword.aspx",


### PR DESCRIPTION
This page directly contains the form

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)