### PR TITLE
add change password url for chewy.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -7,6 +7,7 @@
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
     "censys.io": "https://censys.io/account",
+    "chewy.com": "https://www.chewy.com/app/account/profile",
     "cloudflare.com": "https://dash.cloudflare.com/profile/authentication",
     "consumidor.gov.br": "https://www.consumidor.gov.br/pages/usuario/editar",
     "crunchyroll.com": "https://www.crunchyroll.com/acct",


### PR DESCRIPTION
The form is directly on this page

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)