### PR TITLE
add change password url for stonly

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -54,6 +54,7 @@
     "sonos.com": "https://www.sonos.com/myaccount/user/profile/",
     "stacksocial.com": "https://stacksocial.com/user?show=account-tab",
     "steampowered.com": "https://help.steampowered.com/wizard/HelpChangePassword?redir=store/account/",
+    "stonly.com": "https://app.stonly.com/app/general/userSettings/Account",
     "teamviewer.com": "https://login.teamviewer.com/nav/profile/change-password",
     "thenounproject.com": "https://thenounproject.com/accounts/password/change/",
     "thetrainline.com": "https://www.thetrainline.com/my-account/change-password",


### PR DESCRIPTION
The form exists in a modal triggered by a button on this page

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)