### PR TITLE
Fix Call of Duty password change URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -17,7 +17,7 @@
     "birkenstock.com": "https://www.birkenstock.com/profile",
     "blutdruck-shop.de": "https://www.blutdruck-shop.de/mein-passwort/",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
-    "callofduty.com": "https://profile.callofduty.com/cod/prefs",
+    "callofduty.com": "https://profile.callofduty.com/cod/info",
     "censys.io": "https://censys.io/account",
     "chewy.com": "https://www.chewy.com/app/account/profile",
     "cloudflare.com": "https://dash.cloudflare.com/profile/authentication",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

While the existing URL would bring you to the right page, this improved one brings you directly to account information edit section.

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
