### PR TITLE
Add password rule for robinhood.com (min only required)

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -213,6 +213,9 @@
     "riteaid.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
+    "robinhood.com": {
+        "password-rules": "minlength: 10;"
+    },
     "ruten.com.tw": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower, upper;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [X] The top-level JSON objects are sorted alphabetically 
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

This is to add the password requirements for https://robinhood.com/ .
The only requirement is a min_length of 10.

![image](https://user-images.githubusercontent.com/24778724/84164950-1d561b80-aa41-11ea-911d-3d50da29c395.png)
