### PR TITLE
Add entries from the bitwarden equivalent domains list

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -1,12 +1,90 @@
 [
     [
+        "1800contacts.com",
+        "800contacts.com"
+    ],
+    [
+        "37signals.com",
+        "basecamp.com",
+        "basecamphq.com",
+        "highrisehq.com"
+    ],
+    [
         "aa.com",
         "americanairlines.com",
         "americanairlines.jp"
     ],
     [
+        "accountonline.com",
+        "citi.com",
+        "citibank.com",
+        "citibankonline.com",
+        "citicards.com"
+    ],
+    [
         "aetna.com",
         "banneraetna.myplanportal.com"
+    ],
+    [
+        "airbnb.at",
+        "airbnb.be",
+        "airbnb.ca",
+        "airbnb.ch",
+        "airbnb.cl",
+        "airbnb.co.cr",
+        "airbnb.co.id",
+        "airbnb.co.in",
+        "airbnb.co.kr",
+        "airbnb.co.nz",
+        "airbnb.co.uk",
+        "airbnb.co.ve",
+        "airbnb.com",
+        "airbnb.com.ar",
+        "airbnb.com.au",
+        "airbnb.com.bo",
+        "airbnb.com.br",
+        "airbnb.com.bz",
+        "airbnb.com.co",
+        "airbnb.com.ec",
+        "airbnb.com.gt",
+        "airbnb.com.hk",
+        "airbnb.com.hn",
+        "airbnb.com.mt",
+        "airbnb.com.my",
+        "airbnb.com.ni",
+        "airbnb.com.pa",
+        "airbnb.com.pe",
+        "airbnb.com.py",
+        "airbnb.com.sg",
+        "airbnb.com.sv",
+        "airbnb.com.tr",
+        "airbnb.com.tw",
+        "airbnb.cz",
+        "airbnb.de",
+        "airbnb.dk",
+        "airbnb.es",
+        "airbnb.fi",
+        "airbnb.fr",
+        "airbnb.gr",
+        "airbnb.gy",
+        "airbnb.hu",
+        "airbnb.ie",
+        "airbnb.is",
+        "airbnb.it",
+        "airbnb.jp",
+        "airbnb.mx",
+        "airbnb.nl",
+        "airbnb.no",
+        "airbnb.pl",
+        "airbnb.pt",
+        "airbnb.ru",
+        "airbnb.se"
+    ],
+    [
+        "alibaba.com",
+        "aliexpress.com",
+        "aliyun.com",
+        "net.cn"
     ],
     [
         "alltrails.com",
@@ -26,6 +104,7 @@
         "amazon.nl",
         "amazon.es",
         "amazon.com.tr",
+        "amazon.co.nz",
         "amazon.co.uk"
     ],
     [
@@ -55,6 +134,47 @@
         "att.net"
     ],
     [
+        "autodesk.com",
+        "tinkercad.com"
+    ],
+    [
+        "avon.com",
+        "youravon.com"
+    ],
+    [
+        "azure.com",
+        "bing.com",
+        "hotmail.com",
+        "live.com",
+        "microsoft.com",
+        "microsoftonline.com",
+        "microsoftstore.com",
+        "msn.com",
+        "office.com",
+        "office365.com",
+        "passport.net",
+        "skype.com",
+        "windows.com",
+        "windowsazure.com",
+        "xbox.com"
+    ],
+    [
+        "bananarepublic.com",
+        "gap.com",
+        "oldnavy.com",
+        "piperlime.com"
+    ],
+    [
+        "bankofamerica.com",
+        "bofa.com",
+        "mbna.com",
+        "usecfo.com"
+    ],
+    [
+        "bank-yahav.co.il",
+        "bankhapoalim.co.il"
+    ],
+    [
         "beachbodyondemand.com",
         "teambeachbody.com"
     ],
@@ -77,8 +197,27 @@
         "whistlerblackcomb.com"
     ],
     [
+        "belkin.com",
+        "seedonk.com"
+    ],
+    [
         "boudinbakery.com",
         "boudincatering.com"
+    ],
+    [
+        "cagreatamerica.com",
+        "canadaswonderland.com",
+        "carowinds.com",
+        "cedarfair.com",
+        "cedarpoint.com",
+        "dorneypark.com",
+        "kingsdominion.com",
+        "knotts.com",
+        "miadventure.com",
+        "schlitterbahn.com",
+        "valleyfair.com",
+        "visitkingsisland.com",
+        "worldsoffun.com"
     ],
     [
         "capitalone.com",
@@ -89,17 +228,55 @@
         "asiamiles.com"
     ],
     [
-        "citi.com",
-        "citibank.com",
-        "citibankonline.com"
+        "century21.com",
+        "21online.com"
     ],
     [
+        "chart.io",
+        "chartio.com"
+    ],
+    [
+        "cnet.com",
+        "cnettv.com",
+        "com.com",
+        "download.com",
+        "news.com",
+        "search.com",
+        "upload.com"
+    ],
+    [
+        "comcast.com",
         "comcast.net",
         "xfinity.com"
     ],
     [
+        "cox.com",
+        "cox.net",
+        "coxbusiness.com"
+    ],
+    [
+        "cricketwireless.com",
+        "aiowireless.com"
+    ],
+    [
+        "dcu.org",
+        "dcu-online.org"
+    ],
+    [
         "dinersclubnorthamerica.com",
         "dinersclubus.com"
+    ],
+    [
+        "discordapp.com",
+        "discord.com"
+    ],
+    [
+        "discountbank.co.il",
+        "telebank.co.il"
+    ],
+    [
+        "discover.com",
+        "discovercard.com"
     ],
     [
         "dish.com",
@@ -107,6 +284,9 @@
         "dishnetwork.com"
     ],
     [
+        "disney.com",
+        "disneymoviesanywhere.com",
+        "dadt.com",
         "disneystore.com",
         "shopdisney.com",
         "go.com"
@@ -116,8 +296,19 @@
         "docusign.net"
     ],
     [
+        "dnsomatic.com",
+        "opendns.com",
+        "umbrella.com"
+    ],
+    [
         "dropbox.com",
         "getdropbox.com"
+    ],
+    [
+        "ea.com",
+        "origin.com",
+        "play4free.com",
+        "tiberiumalliance.com"
     ],
     [
         "ebay.at",
@@ -137,11 +328,64 @@
         "ebay.es",
         "ebay.fr",
         "ebay.ie",
+        "ebay.in",
         "ebay.it",
         "ebay.nl",
         "ebay.ph",
         "ebay.pl",
         "ebay.vn"
+    ],
+    [
+        "envato.com",
+        "themeforest.net",
+        "codecanyon.net",
+        "videohive.net",
+        "audiojungle.net",
+        "graphicriver.net",
+        "photodune.net",
+        "3docean.net"
+    ],
+    [
+        "eventbrite.at",
+        "eventbrite.be",
+        "eventbrite.ca",
+        "eventbrite.ch",
+        "eventbrite.cl",
+        "eventbrite.co.id",
+        "eventbrite.co.in",
+        "eventbrite.co.kr",
+        "eventbrite.co.nz",
+        "eventbrite.co.uk",
+        "eventbrite.co.ve",
+        "eventbrite.com",
+        "eventbrite.com.au",
+        "eventbrite.com.bo",
+        "eventbrite.com.br",
+        "eventbrite.com.co",
+        "eventbrite.com.hk",
+        "eventbrite.com.hn",
+        "eventbrite.com.pe",
+        "eventbrite.com.sg",
+        "eventbrite.com.tr",
+        "eventbrite.com.tw",
+        "eventbrite.cz",
+        "eventbrite.de",
+        "eventbrite.dk",
+        "eventbrite.fi",
+        "eventbrite.fr",
+        "eventbrite.gy",
+        "eventbrite.hu",
+        "eventbrite.ie",
+        "eventbrite.is",
+        "eventbrite.it",
+        "eventbrite.jp",
+        "eventbrite.mx",
+        "eventbrite.nl",
+        "eventbrite.no",
+        "eventbrite.pl",
+        "eventbrite.pt",
+        "eventbrite.ru",
+        "eventbrite.se"
     ],
     [
         "facebook.com",
@@ -160,22 +404,26 @@
         "gogoinflight.com"
     ],
     [
+        "gotomeeting.com",
+        "citrixonline.com"
+    ],
+    [
+        "gmail.com",
+        "google.com",
+        "youtube.com"
+    ],
+    [
+        "healthcare.gov",
+        "cms.gov"
+    ],
+    [
         "intuit.com",
-        "mint.com"
+        "mint.com",
+        "turbotax.com"
     ],
     [
         "kaiserpermanente.org",
         "kp.org"
-    ],
-    [
-        "live.com",
-        "skype.com"
-    ],
-    [
-        "live.com",
-        "microsoft.com",
-        "microsoftonline.com",
-        "office.com"
     ],
     [
         "lookmark.io",
@@ -193,6 +441,70 @@
         "starwoodhotels.com"
     ],
     [
+        "mandtbank.com",
+        "mtb.com"
+    ],
+    [
+        "mathletics.com",
+        "mathletics.com.au",
+        "mathletics.co.uk"
+    ],
+    [
+        "mdsol.com",
+        "imedidata.com"
+    ],
+    [
+        "mediawiki.org",
+        "wikibooks.org",
+        "wikidata.org",
+        "wikimedia.org",
+        "wikinews.org",
+        "wikipedia.org",
+        "wikiquote.org",
+        "wikisource.org",
+        "wikiversity.org",
+        "wikivoyage.org",
+        "wiktionary.org"
+    ],
+    [
+        "mercadolivre.com",
+        "mercadolivre.com.br",
+        "mercadolibre.com",
+        "mercadolibre.com.ar",
+        "mercadolibre.com.mx"
+    ],
+    [
+        "merrilledge.com",
+        "ml.com",
+        "mymerrill.com"
+    ],
+    [
+        "mi.com",
+        "xiaomi.com"
+    ],
+    [
+        "minecraft.com",
+        "mojang.com"
+    ],
+    [
+        "morganstanley.com",
+        "morganstanleyclientserv.com",
+        "stockplanconnect.com",
+        "ms.com"
+    ],
+    [
+        "mynortonaccount.com",
+        "norton.com"
+    ],
+    [
+        "mysql.com",
+        "oracle.com" 
+    ],
+    [
+        "myuv.com",
+        "uvvu.com"
+    ],
+    [
         "nokia.com",
         "withings.com"
     ],
@@ -201,12 +513,70 @@
         "optum.com"
     ],
     [
+        "paypal.com",
+        "paypal-search.com"
+    ],
+    [
+        "pepco.com",
+        "pepcoholdings.com"
+    ],
+    [
+        "playstation.com",
+        "sonyentertainmentnetwork.com"
+    ],
+    [
         "pocket.com",
         "getpocket.com"
     ],
     [
+        "pokemon.com",
+        "pokemon-gl.com"
+    ],
+    [
+        "postepay.it",
+        "poste.it"
+    ],
+    [
+        "railnation.ru",
+        "railnation.de",
+        "rail-nation.com",
+        "railnation.gr",
+        "railnation.us",
+        "trucknation.de",
+        "traviangames.com"
+    ],
+    [
+        "rakuten.com",
+        "buy.com"
+    ],
+    [
         "scholarshare529.com",
         "secureaccountview.com"
+    ],
+    [
+        "sears.com",
+        "shld.net"
+    ],
+    [
+        "schwab.com",
+        "schwabplan.com"
+    ],
+    [
+        "shopify.com",
+        "myshopify.com"
+    ],
+    [
+        "siriusxm.com",
+        "sirius.com"
+    ],
+    [
+        "skysports.com",
+        "skybet.com",
+        "skyvegas.com"
+    ],
+    [
+        "snapfish.com",
+        "snapfish.ca"
     ],
     [
         "spark.net",
@@ -221,11 +591,26 @@
         "askubuntu.com",
         "serverfault.com",
         "stackexchange.com",
-        "superuser.com"
+        "superuser.com",
+        "mathoverflow.net"
     ],
     [
         "steampowered.com",
-        "steamcommunity.com"
+        "steamcommunity.com",
+        "steamgames.com"
+    ],
+    [
+        "sprint.com",
+        "sprintpcs.com",
+        "nextel.com"
+    ],
+    [
+        "taxact.com",
+        "taxactonline.com"
+    ],
+    [
+        "techdata.com",
+        "techdata.ch"
     ],
     [
         "telekom-dienste.de",
@@ -240,6 +625,16 @@
         "livenation.com"
     ],
     [
+        "ua2go.com",
+        "ual.com",
+        "united.com",
+        "unitedwifi.com"
+    ],
+    [
+        "ubnt.com",
+        "ui.com"
+    ],
+    [
         "uhc.com",
         "myuhc.com"
     ],
@@ -251,8 +646,8 @@
         "missouri.edu"
     ],
     [
-        "united.com",
-        "unitedwifi.com"
+        "verizon.com",
+        "verizon.net"
     ],
     [
         "verizonwireless.com",
@@ -263,6 +658,10 @@
         "wayfair.ca"
     ],
     [
+        "wellsfargo.com",
+        "wf.com"
+    ],
+    [
         "wilson.com",
         "slugger.com",
         "atecsports.com",
@@ -271,11 +670,32 @@
         "luxilon.com"
     ],
     [
+        "wpcu.coop",
+        "wpcuonline.com"
+    ],
+    [
         "wsj.com",
         "dowjones.com"
     ],
     [
+        "x10hosting.com",
+        "x10premium.com"
+    ],
+    [
+        "xiami.com",
+        "alipay.com"
+    ],
+    [
         "yahoo.com",
-        "flickr.com"
+        "flickr.com",
+        "overture.com"
+    ],
+    [
+        "zendesk.com",
+        "zopim.com"
+    ],
+    [
+        "zonealarm.com",
+        "zonelabs.com"
     ]
 ]


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [X] The top-level JSON objects are sorted alphabetically 
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [X] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [X] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

All of these shared credential sites are sourced from Bitwarden's own internal list: https://github.com/bitwarden/server/blob/master/src/Core/Utilities/StaticStore.cs

I feel strongly that all of these additions and modifications are of quality since they are a from an open source project that has hundreds of thousands of users on their own hosted offering (and many more users hosting their own instance of the service). If any of these were wrong I believe that users would have immediately submitted pull requests to modify these.
