### PR TITLE
add password rules for ancestry.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -14,6 +14,9 @@
     "americanexpress.com": {
         "password-rules": "minlength: 8; maxlength: 20;"
     },
+    "ancestry.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^-_`{|}~]];"
+    },
     "angieslist.com": {
         "password-rules": "minlength: 6; maxlength: 15;"
     },


### PR DESCRIPTION
Instructions dropdown during password creation below
<img width="441" alt="ancestry-password-rules" src="https://user-images.githubusercontent.com/5795115/84219682-13630580-aa9f-11ea-9b41-6e4451404e08.png">

Also tested with a password containing all of the included special characters

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.