### PR TITLE
add change password url for carta

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -18,6 +18,7 @@
     "blutdruck-shop.de": "https://www.blutdruck-shop.de/mein-passwort/",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
     "callofduty.com": "https://profile.callofduty.com/cod/info",
+    "carta.com": "https://app.carta.com/profiles/update/",
     "censys.io": "https://censys.io/account",
     "chewy.com": "https://www.chewy.com/app/account/profile",
     "cloudflare.com": "https://dash.cloudflare.com/profile/authentication",


### PR DESCRIPTION
Contains an "edit" button that when click displays a modal for change

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)