### PR TITLE
Update password-rules.json

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -17,6 +17,9 @@
     "angieslist.com": {
         "password-rules": "minlength: 6; maxlength: 15;"
     },
+     "animekaizoku.com": {
+        "password-rules": "minlength: 8;"
+    },
     "artscyclery.com": {
         "password-rules": "minlength: 6; maxlength: 19;"
     },
@@ -281,9 +284,5 @@
     },
     "zoom.us": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; max-consecutive: 6;"
-    },
-    "animekaizoku.com": {
-        "password-rules": "minlength: 8;"
-    },
-    
+    }, 
 }

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -281,5 +281,9 @@
     },
     "zoom.us": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; max-consecutive: 6;"
-    }
+    },
+    "animekaizoku.com": {
+        "password-rules": "minlength: 8;"
+    },
+    
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
