### PR TITLE
Add Wikimedia projects

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -263,7 +263,6 @@
         "wayfair.ca"
     ],
     [
-        "wikimedia.org",
         "wikipedia.org",
         "mediawiki.org",
         "wikibooks.org",
@@ -273,7 +272,13 @@
         "wikisource.org",
         "wikiversity.org",
         "wikivoyage.org",
-        "wiktionary.org"
+        "wiktionary.org",
+        "commons.wikimedia.org",
+        "meta.wikimedia.org",
+        "incubator.wikimedia.org",
+        "outreach.wikimedia.org",
+        "species.wikimedia.org",
+        "wikimania.wikimedia.org"
     ],
     [
         "wilson.com",

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -263,6 +263,19 @@
         "wayfair.ca"
     ],
     [
+        "wikimedia.org",
+        "wikipedia.org",
+        "mediawiki.org",
+        "wikibooks.org",
+        "wikidata.org",
+        "wikinews.org",
+        "wikiquote.org",
+        "wikisource.org",
+        "wikiversity.org",
+        "wikivoyage.org",
+        "wiktionary.org"
+    ],
+    [
         "wilson.com",
         "slugger.com",
         "atecsports.com",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)
  
  
These are all Wikimedia projects which share credentials https://www.wikimedia.org/