### PR TITLE
Add password rules for aetna.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -2,6 +2,9 @@
     "163.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },
+    "aetna.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: upper; required: digit; max-consecutive: 2; allowed: lower, [_&-#@];"
+    },
     "airasia.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
<img width="502" alt="Screen Shot 2020-06-10 at 10 53 25 PM" src="https://user-images.githubusercontent.com/234616/84349919-33f99100-ab6d-11ea-8bdd-7d76f8096a46.png">

<img width="717" alt="Screen Shot 2020-06-10 at 10 53 37 PM" src="https://user-images.githubusercontent.com/234616/84349930-3b209f00-ab6d-11ea-8008-cab8b0743b99.png">

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)