### PR TITLE
Add mailbox.org -- append 2fa to password

### DIFF
--- a/quirks/websites-that-append-2fa-to-password.json
+++ b/quirks/websites-that-append-2fa-to-password.json
@@ -1,4 +1,5 @@
 [
     "etrade.com",
+    "mailbox.org",
     "usaa.com"
 ]


### PR DESCRIPTION
mailbox.org requires appending 2fa to the log-in pin

Source (in German): [https://kb.mailbox.org/display/MAILBOX/Die+Zwei-Faktor-Authentifizierung+einrichten](https://kb.mailbox.org/display/MAILBOX/Die+Zwei-Faktor-Authentifizierung+einrichten)

Relevant part:

"4-stelligen Geheimcode und ohne Leerzeichen direkt dahinter das generierte Einmalkennwort eingeben" ("enter your 4-digit pin followed by (without spaces) the generated one-time-password")

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.


