### PR TITLE
Added hotwire.com password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -150,6 +150,9 @@
     "hotels.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@$!#()&^*%];"
     },
+    "hotwire.com": {
+        "password-rules": "minlength: 6; maxlength: 30; allowed: upper, lower, digit, [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?]];"
+    },
     "hrblock.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [$#%!];"
     },


### PR DESCRIPTION
Hi,

I've added the password rules for hotwire.com. There are three restrictions for the website, min:6, max:30, and that spaces are not allowed.

I believe I've properly implemented the last restriction. The website seems to allow any other characters, including emoji, so this may actually be more restrictive than needed, but I was unsure how to block everything except spaces.

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)

<img width="379" alt="Screen Shot 2020-06-11 at 6 01 08 PM" src="https://user-images.githubusercontent.com/1449259/84443406-8b4f3e00-ac0d-11ea-9b1d-758d91cf1b39.png">