### PR TITLE
Added password-rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -74,7 +74,6 @@
     "coursera.com": {
         "password-rules": "minlength: 8; maxlength: 72;"
     },
-
     "crateandbarrel.com": {
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -258,6 +258,9 @@
     "ubisoft.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-]; required: [!@#$%^&*()+];"
     },
+    "Udacity.com": {
+        "password-rules": "minlength: 8;"
+    },
     "udel.edu": {
         "password-rules": "minlength: 12; maxlength: 30; required: lower; required: upper; required: digit; required: [!@#$%^&*()+];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -71,6 +71,10 @@
     "consorsfinanz.de": {
         "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit, [-.];"
     },
+    "coursera.com": {
+        "password-rules": "minlength: 8; maxlength: 72;"
+    },
+
     "crateandbarrel.com": {
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -258,7 +258,7 @@
     "ubisoft.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-]; required: [!@#$%^&*()+];"
     },
-    "Udacity.com": {
+    "udacity.com": {
         "password-rules": "minlength: 8;"
     },
     "udel.edu": {


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
