### PR TITLE
Add Darty.com to change-password-URLs.json

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -25,6 +25,7 @@
     "codepen.io": "https://codepen.io/settings/account",
     "consumidor.gov.br": "https://www.consumidor.gov.br/pages/usuario/editar",
     "crunchyroll.com": "https://www.crunchyroll.com/acct",
+    "darty.com": "https://www.darty.com/espace_client/donnees-personnelles/mot-de-passe/edition",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",
     "disneyplus.com": "https://www.disneyplus.com/account/change-password",
     "dropbox.com": "https://www.dropbox.com/account/security",


### PR DESCRIPTION
French electrical retailing company

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state