### PR TITLE
Add password rules for darty.com, fnac.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -92,6 +92,9 @@
     "danawa.com": {
         "password-rules": "minlength: 8; maxlength: 21; required: lower, upper; required: digit; required: [!@$%^&*];"
     },
+    "darty.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
+    },
     "delta.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
     },
@@ -134,6 +137,9 @@
     },
     "fc2.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
+    },
+    "fnac.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
     },
     "getflywheel.com": {
         "password-rules": "minlength: 7; maxlength: 72;"


### PR DESCRIPTION
French online retailers

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)

#### Darty.com
<img width="553" alt="darty" src="https://user-images.githubusercontent.com/8578329/84564049-66b7ab00-ad60-11ea-9f3d-7242725bf027.png">

#### Fnac.com

4 of 5 conditions are required, in this case the special characters is skipped.

<img width="336" alt="fnac" src="https://user-images.githubusercontent.com/8578329/84564051-67e8d800-ad60-11ea-9186-506fb7f273b9.png">
