### PR TITLE
axa.de - password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -30,7 +30,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
     "axa.de": {
-        "password-rules": "required: lower; required: upper; required: digit; allowed: [!\"§$%&/()=?;:_-+*\'#]; minlength: 8; maxlength: 65;"
+        "password-rules": "required: lower; required: upper; required: digit; allowed: [!\"§$%&/()=?;:_-+*'#]; minlength: 8; maxlength: 65;"
     },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -30,7 +30,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
     "axa.de": {
-        "password-rules": "required: lower; required: upper; required: digit; allowed: [!\"§$%&/()=?;:_-+*'#]; minlength: 8; maxlength: 65;"
+        "password-rules": "minlength: 8; maxlength: 65; required: lower; required: upper; required: digit; allowed: [!\"§$%&/()=?;:_-+*'#];"
     },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -29,6 +29,9 @@
     "autify.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
+    "axa.de": {
+        "password-rules": "required: lower; required: upper; required: digit; allowed: [!“§$%&/()=?;:_-+*’#]; minlength: 8; maxlength: 65;"
+    },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -30,7 +30,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
     "axa.de": {
-        "password-rules": "required: lower; required: upper; required: digit; allowed: [!\"§$%&/()=?;:_-+*\’#]; minlength: 8; maxlength: 65;"
+        "password-rules": "required: lower; required: upper; required: digit; allowed: [!\"§$%&/()=?;:_-+*\'#]; minlength: 8; maxlength: 65;"
     },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -30,7 +30,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
     "axa.de": {
-        "password-rules": "required: lower; required: upper; required: digit; allowed: [!“§$%&/()=?;:_-+*’#]; minlength: 8; maxlength: 65;"
+        "password-rules": "required: lower; required: upper; required: digit; allowed: [!\"§$%&/()=?;:_-+*\’#]; minlength: 8; maxlength: 65;"
     },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"


### PR DESCRIPTION
**Adding password rule for axa.de**

- Minimum length = 8 (see screenshot), maximum length = 65 (determined by testing)
- Additionally the password has to contain 3 out of 4 of the following criteria: lower, upper, digit, special characters (Proposed password rule requires lower, upper and digits. Special characters are allowed.) 

![Passwort mit mindestens 8 Zeichen](https://user-images.githubusercontent.com/27491477/84592864-f46ec580-ae48-11ea-82c4-e5dd0ac1ca30.png)

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
