### PR TITLE
Added Change Password URL for virginmobile.ca

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -83,6 +83,7 @@
     "udel.edu": "https://udapps.nss.udel.edu/myUDsettings/password",
     "umsystem.edu": "https://password.umsystem.edu/reset/",
     "usaa.com": "https://www.usaa.com/inet/ent_auth_password/pages/ChangePasswordPage",
+    "virginmobile.ca": "https://myaccount.virginmobile.ca/MyProfile/Details/EditProfile?editField=PASSWORD",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",
     "yahoo.com": "https://login.yahoo.com/account/change-password",
     "zhihu.com": "https://www.zhihu.com/settings/account",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state