### PR TITLE
In character classes that include the character '-', move '-' to be t…

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -3,7 +3,7 @@
         "password-rules": "minlength: 6; maxlength: 16;"
     },
     "aetna.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: upper; required: digit; max-consecutive: 2; allowed: lower, [_&-#@];"
+        "password-rules": "minlength: 8; maxlength: 20; required: upper; required: digit; max-consecutive: 2; allowed: lower, [-_&#@];"
     },
     "airasia.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
@@ -18,7 +18,7 @@
         "password-rules": "minlength: 8; maxlength: 20;"
     },
     "ancestry.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^-_`{|}~]];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [-!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
     "angieslist.com": {
         "password-rules": "minlength: 6; maxlength: 15;"
@@ -30,13 +30,13 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
     "axa.de": {
-        "password-rules": "minlength: 8; maxlength: 65; required: lower; required: upper; required: digit; allowed: [!\"§$%&/()=?;:_-+*'#];"
+        "password-rules": "minlength: 8; maxlength: 65; required: lower; required: upper; required: digit; allowed: [-!\"§$%&/()=?;:_+*'#];"
     },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"
     },
     "bankofamerica.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [@#*()+={}/?~;,.-_];"
+        "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [-@#*()+={}/?~;,._];"
     },
     "bhphotovideo.com": {
         "password-rules": "maxlength: 15;"
@@ -172,7 +172,7 @@
         "password-rules": "minlength: 6; maxlength: 10; required: lower, upper, digit; allowed: [!\"#$%&()*+:;<=>?@[{}~]];"
     },
     "id.sonyentertainmentnetwork.com": {
-        "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [!@#-^&*=+;:];"
+        "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
     "idestination.info": {
         "password-rules": "maxlength: 15;"
@@ -184,7 +184,7 @@
         "password-rules": "minlength: 8; maxlength: 16;"
     },
     "key.harvard.edu": {
-        "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [@_#!&$`%*+()./,;~:{}|?>=<^['-]];"
+        "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^[']];"
     },
     "klm.com": {
         "password-rules": "minlength: 8; maxlength: 12;"
@@ -211,7 +211,7 @@
         "password-rules": "minlength: 6; maxlength: 20;"
     },
     "myaccess.dmdc.osd.mil": {
-        "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [@_#!&$`%*+()./,;~:{}|?>=<^'-[]];"
+        "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
     "myhealthrecord.com": {
         "password-rules": "minlength: 8; maxlength: 20; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.!$*=];"
@@ -256,7 +256,7 @@
         "password-rules": "minlength: 10; maxlength: 30; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%*()_+^}{:;?.];"
     },
     "signin.ea.com": {
-        "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [!@#-^&*=+;:];"
+        "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
     "southwest.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^*(),.;:/\\];"


### PR DESCRIPTION
…he first character, as required by the specification draft

### Checklist
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.