### PR TITLE
adding Sony sites to shared credential backends

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -209,6 +209,10 @@
         "secureaccountview.com"
     ],
     [
+        "sonyentertainmentnetwork.com",
+        "sony.com"
+    ],
+    [
         "spark.net",
         "jdate.com"
     ],


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

Closes #75 

<img width="1440" alt="Bildschirmfoto 2020-06-17 um 00 29 46" src="https://user-images.githubusercontent.com/25909319/84834870-aa493800-b032-11ea-8e16-f9f6134ffd18.png">
<img width="1440" alt="Bildschirmfoto 2020-06-17 um 00 31 10" src="https://user-images.githubusercontent.com/25909319/84834883-b33a0980-b032-11ea-88ca-3bc6f74ca36e.png">