### PR TITLE
Added udacity.com to change-password-URLs.json

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -91,5 +91,6 @@
     "yahoo.com": "https://login.yahoo.com/account/change-password",
     "zhihu.com": "https://www.zhihu.com/settings/account",
     "zocdoc.com": "https://www.zocdoc.com/patient/editprofile?section=Password",
-    "zoom.us": "https://zoom.us/profile#pwd-form"
+    "zoom.us": "https://zoom.us/profile#pwd-form",
+    "udacity.com": "https://classroom.udacity.com/settings/password",
 }

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -83,6 +83,7 @@
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
     "twilio.com": "https://www.twilio.com/console/user/settings",
     "twitch.tv": "https://www.twitch.tv/settings/security",
+    "udacity.com": "https://classroom.udacity.com/settings/password",
     "udel.edu": "https://udapps.nss.udel.edu/myUDsettings/password",
     "umsystem.edu": "https://password.umsystem.edu/reset/",
     "usaa.com": "https://www.usaa.com/inet/ent_auth_password/pages/ChangePasswordPage",
@@ -92,5 +93,4 @@
     "zhihu.com": "https://www.zhihu.com/settings/account",
     "zocdoc.com": "https://www.zocdoc.com/patient/editprofile?section=Password",
     "zoom.us": "https://zoom.us/profile#pwd-form",
-    "udacity.com": "https://classroom.udacity.com/settings/password",
 }

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -92,5 +92,5 @@
     "yahoo.com": "https://login.yahoo.com/account/change-password",
     "zhihu.com": "https://www.zhihu.com/settings/account",
     "zocdoc.com": "https://www.zocdoc.com/patient/editprofile?section=Password",
-    "zoom.us": "https://zoom.us/profile#pwd-form",
+    "zoom.us": "https://zoom.us/profile#pwd-form"
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
