### PR TITLE
Cecredentialtrust.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -20,6 +20,7 @@
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
     "callofduty.com": "https://profile.callofduty.com/cod/info",
     "carta.com": "https://app.carta.com/profiles/update/",
+    "cecredentialtrust.com": "https://secure.cecredentialtrust.com/account/editpassword/",
     "censys.io": "https://censys.io/account",
     "chewy.com": "https://www.chewy.com/app/account/profile",
     "cloudflare.com": "https://dash.cloudflare.com/profile/authentication",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -59,6 +59,9 @@
     "cb2.com": {
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },
+    "cecredentialtrust.com": {
+        "password-rules": "minlength: 12; required: lower; required: upper; required: digit; required: [!#$%&*@^];"
+    },
     "chase.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower, upper; required: digit; required: [!#$%+/=@~]; max-consecutive: 2;"
     },


### PR DESCRIPTION
### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
- [x] I agree to the project’s [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)


#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)

<img width="1184" alt="Screen Shot 2020-06-17 at 1 31 28 PM" src="https://user-images.githubusercontent.com/1449259/84930548-7bb57680-b09f-11ea-822f-e71bbb174764.png">
