### PR TITLE
add password rules for 1800flowers

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -2,6 +2,9 @@
     "163.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },
+    "1800flowers.com": {
+        "password-rules": "minlength: 6; required: lower, upper; required: digit;"
+    },
     "aetna.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: digit; max-consecutive: 2; allowed: lower, [-_&#@];"
     },


### PR DESCRIPTION
![1800flowers-password-rules](https://user-images.githubusercontent.com/5795115/85055315-59892a80-b16b-11ea-8390-0eada6d2cce9.gif)

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
- [x]  I agree to the project's Developer Certificate of Origin.

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)