### PR TITLE
add change password url for aesop

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -4,6 +4,7 @@
     "aa.com": "https://www.aa.com/loyalty/profile/information",
     "acorns.com": "https://app.acorns.com/settings/change-password",
     "adobe.com": "https://account.adobe.com/security",
+    "aesop.com": "https://www.aesop.com/my-account",
     "airbnb.com": "https://www.airbnb.com/account-settings/login-and-security",
     "alliantcreditunion.com": "https://www.alliantcreditunion.com/OnlineBanking/Settings/AccessAndSecurity/ChangePassword.aspx",
     "alternate.de": "https://www.alternate.de/html/myAccount/account/basicData.html",


### PR DESCRIPTION
This URL is local agnostic but redirects to a URL with the users chosen locale and the "my-account" view which contains the collapsed form. (A login form is provided as an overlay if not logged in)

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
- [x]  I agree to the project's Developer Certificate of Origin.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state