### PR TITLE
add change password url for heroku

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -37,6 +37,7 @@
     "gog.com": "https://www.gog.com/account/settings/security",
     "gov.br": "https://acesso.gov.br/area-cidadao/#/alterarSenha",
     "grubhub.com": "https://www.grubhub.com/account/profile",
+    "heroku.com": "https://dashboard.heroku.com/account",
     "impots.gouv.fr": "https://cfspart.impots.gouv.fr/monprofil-webapp/GererMonProfil",
     "key.harvard.edu": "https://key.harvard.edu/manage-account/change-password",
     "lemonde.fr": "https://moncompte.lemonde.fr/gcustomer/account/password",


### PR DESCRIPTION
This URL contains the uncollapsed form directly and redirects during or after login.

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
- [x]  I agree to the project's Developer Certificate of Origin.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state