### PR TITLE
Updating paypal.com password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -232,7 +232,7 @@
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },
     "paypal.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: digit, [!@#$%^&*()]; allowed: lower, upper;"
+        "password-rules": "minlength: 8; maxlength: 20; required: digit, [!@#$%^&*()]; required: lower, upper; max-consecutive: 3"
     },
     "pilotflyingj.com": {
         "password-rules": "minlength: 7; required: digit; allowed: lower, upper;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -232,7 +232,7 @@
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },
     "paypal.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: digit, [!@#$%^&*()]; required: lower, upper; max-consecutive: 3"
+        "password-rules": "minlength: 8; maxlength: 20; required: digit, [!@#$%^&*()]; required: lower, upper; max-consecutive: 3;"
     },
     "pilotflyingj.com": {
         "password-rules": "minlength: 7; required: digit; allowed: lower, upper;"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)

### Description

Added `max-consecutive: 3` because PayPal doesn't allow 4 or more consecutive characters:

![IMG_6671](https://user-images.githubusercontent.com/27491477/85436610-9d27ce00-b589-11ea-8413-7199705cb8af.jpeg)

Changed `allowed: lower, upper` to `required: lower, upper`, because when `required: digit, [!@#$%^&*()]` PayPal demands at least one letter:

![IMG_6671](https://user-images.githubusercontent.com/27491477/85436974-26d79b80-b58a-11ea-8968-5485f6b8c123.jpeg)
![IMG_6675](https://user-images.githubusercontent.com/27491477/85436989-30f99a00-b58a-11ea-9487-ac2bacd289af.jpeg)

