### PR TITLE
add change password url for zeplin

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -95,6 +95,7 @@
     "virginmobile.ca": "https://myaccount.virginmobile.ca/MyProfile/Details/EditProfile?editField=PASSWORD",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",
     "yahoo.com": "https://login.yahoo.com/account/change-password",
+    "zeplin.io": "https://app.zeplin.io/profile/password",
     "zhihu.com": "https://www.zhihu.com/settings/account",
     "zocdoc.com": "https://www.zocdoc.com/patient/editprofile?section=Password",
     "zoom.us": "https://zoom.us/profile#pwd-form"


### PR DESCRIPTION
This URL redirects to the change password form whether the user is logged in or out. If the user is logged out they are sent to the login for and the redirect takes place after.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state