### PR TITLE
add change password url for walgreens

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -93,6 +93,7 @@
     "umsystem.edu": "https://password.umsystem.edu/reset/",
     "usaa.com": "https://www.usaa.com/inet/ent_auth_password/pages/ChangePasswordPage",
     "virginmobile.ca": "https://myaccount.virginmobile.ca/MyProfile/Details/EditProfile?editField=PASSWORD",
+    "walgreens.com": "https://www.walgreens.com/account/user_and_password",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",
     "yahoo.com": "https://login.yahoo.com/account/change-password",
     "zhihu.com": "https://www.zhihu.com/settings/account",


### PR DESCRIPTION
This URL redirects to the change password form whether the user is logged in or out. If the user is logged out they are sent to the login for and the redirect takes place after.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state