### PR TITLE
move common practice checklist item to password rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,10 +11,10 @@
 
 #### for change-password-URLs.json
 - [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
-- [ ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
 - [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
 
 #### for password-rules.json
 - [ ] The given rule isn't particularly standard and obvious for password managers
 - [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
 - [ ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
+- [ ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)


### PR DESCRIPTION
@rmondello I saw that you moved the common practice checklist item in [your PR around adding the "Developer Certificate of Origin"](https://github.com/apple/password-manager-resources/commit/aff867d345e81d2f71e966cae3a1aac87e1e7827#diff-195a635ad245ded9076330e31134bd80R14) but I think it makes more sense to include with the password rules. (Let me know if you disagree)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update