### PR TITLE
Add password rule for apple.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -26,6 +26,9 @@
     "angieslist.com": {
         "password-rules": "minlength: 6; maxlength: 15;"
     },
+    "apple.com": {
+        "password-rules": "minlength: 8; maxlength: 63; required: lower; required: upper; required: digit; allowed: ascii-printable;"
+    },
     "artscyclery.com": {
         "password-rules": "minlength: 6; maxlength: 19;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

### Description

According to Apple's page for creating a new Apple ID ([link](https://appleid.apple.com/account#!&page=create)):

- at least 8 characters
- not more than 63 characters
- at least one upper case letter, one lower case letter and one digit

![Bildschirmfoto 2020-06-29 um 19 37 28](https://user-images.githubusercontent.com/27491477/86039311-8cbc9b00-ba42-11ea-96dc-402744e579a3.png)
![Bildschirmfoto 2020-06-29 um 19 42 18](https://user-images.githubusercontent.com/27491477/86039331-8fb78b80-ba42-11ea-99a2-041949afd737.png)

All ascii-printable characters are allowed as well (determined by testing).

Together this translates into:
`minlength: 8; maxlength: 63; required: lower; required: upper; required: digit; allowed: ascii-printable;`


