### PR TITLE
Added www4.irs.gov password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -345,6 +345,9 @@
     "wsj.com": {
         "password-rules": "maxlength: 15;"
     },
+    "www4.irs.gov": {
+        "password-rules": "required: lower; required: upper; required: digit; required: [!#$%&*@]; minlength: 8; maxlength: 32;"
+    },
     "xfinity.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -346,7 +346,7 @@
         "password-rules": "maxlength: 15;"
     },
     "www4.irs.gov": {
-        "password-rules": "required: lower; required: upper; required: digit; required: [!#$%&*@]; minlength: 8; maxlength: 32;"
+        "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [!#$%&*@];"
     },
     "xfinity.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; required: digit;"


### PR DESCRIPTION
This **www4.irs.gov** entry covers a single IRS.gov login system that spans a few subdomains like **sa.www4.irs.gov** & **la.www4.irs.gov**.

_For example, the service linked to from https://www.irs.gov/account lives under "**sa.www4.irs.gov**", and the services linked to from https://www.irs.gov/e-services live under "**la.www4.irs.gov**", and these both share the same login system + password rules._

There are other irs.gov subdomains - outside of www4 - which have different login systems and password requirements; those are not covered in this pull request.

This request is being submitted since the system only allows the **specific symbols** listed in the password rules. Attempts to use other characters will result in failure.

___

**Screenshot of www4.irs.gov password rules:**
![www4 irs gov pw rule screenshot](https://user-images.githubusercontent.com/31887/86402673-3a65bf00-bc7a-11ea-9cd4-8dd739e0fa22.png)
___
**Plaintext reading of www4.irs.gov password rules:**
> Password Rules:
• Between 8 and 32 characters long.
• Must contain at least one numeric and one special character (!@#$%&*).
• At least one uppercase and at least one lowercase letter.
___
**Example showing that other symbols (^) not in their list do not fulfill the "special character" test:**
![special char fail](https://user-images.githubusercontent.com/31887/86403168-28d0e700-bc7b-11ea-8f35-8bbf4d352a0c.png)

___
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [ ] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
