### PR TITLE
Add dkb.de password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -129,7 +129,7 @@
         "password-rules": "minlength: 6; maxlength: 12;"
     },
     "dkb.de": {
-        "password-rules": "minlength: 8; maxlength: 38; required: lower, upper; required: digit; allowed: [äüöÄÜÖß!$%&/()=?+#,.-:];"
+        "password-rules": "minlength: 8; maxlength: 38; required: lower, upper; required: digit; allowed: [-äüöÄÜÖß!$%&/()=?+#,.:];"
     },
     "dmm.com": {
         "password-rules": "minlength: 4; maxlength: 16; required: lower; required: upper; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -128,6 +128,9 @@
     "devstore.cn": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },
+    "dkb.de": {
+        "password-rules": "minlength: 8; maxlength: 38; required: lower, upper; required: digit; allowed: [äüöÄÜÖß!$%&/()=?+#,.-:];"
+    },
     "dmm.com": {
         "password-rules": "minlength: 4; maxlength: 16; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
Password according to Deutsche Kreditbank homepage.
Refer to https://fragen.dkb.de/#!q=passwort%20erlaubte%20zeichen

DKB only requires "a letter" but does not specify its case, chose to go with the most common "lower, upper" for "allow".

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update


#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
