### PR TITLE
Add Discord to shared backends

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -101,6 +101,10 @@
         "dinersclubus.com"
     ],
     [
+        "discord.com",
+        "discordapp.com"
+    ],
+    [
         "dish.com",
         "mydish.com",
         "dishnetwork.com"


### PR DESCRIPTION
Add discord.com/discordapp.com to shared-credential-backends


While not technically falling into the exact specifics of the requirements to be added to this quirk, it seems to meet enough of them that it would be logical to add.

Discord used to previously use https://discordapp.com as their primary branding URL (having owned https://discord.com for some time), but at the beginning of May switched to redirecting https://discordapp.com to https://discord.com. Anyone with the old URL saved in their password manager would need to adjust it to https://discord.com.

![image](https://user-images.githubusercontent.com/7369280/87352344-bb8d4380-c50f-11ea-8abe-b3ecc42a6b8f.png)
![image](https://user-images.githubusercontent.com/7369280/87352355-c1832480-c50f-11ea-884d-578aed3c1694.png)

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

