### PR TITLE
Add password rules for ventrachicago.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -122,6 +122,7 @@
     "udel.edu": "https://udapps.nss.udel.edu/myUDsettings/password",
     "umsystem.edu": "https://password.umsystem.edu/reset/",
     "usaa.com": "https://www.usaa.com/inet/ent_auth_password/pages/ChangePasswordPage",
+    "ventrachicago.com": "https://www.ventrachicago.com/account/manage-account/",
     "virginmobile.ca": "https://myaccount.virginmobile.ca/MyProfile/Details/EditProfile?editField=PASSWORD",
     "vivo.com.br": "https://meuvivo.vivo.com.br/meuvivo/appmanager/portal/fixo",
     "walgreens.com": "https://www.walgreens.com/account/user_and_password",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -355,7 +355,7 @@
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },
     "ventrachicago.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!@#$%^];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [!@#$%^];"
     },
     "vetsfirstchoice.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [?!@$%^+=&];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -354,6 +354,9 @@
     "vanguard.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },
+    "ventrachicago.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!@#$%^];"
+    },
     "vetsfirstchoice.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [?!@$%^+=&];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

When changing a password, the rules are outlined as:
> Password must have a minimum of 8 characters and include one upper case letter, one lower case letter, and at least one number or one of these characters (!@#$%^) No other characters are allowed.
