### PR TITLE
Add password rules for walkhighlands.co.uk

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -367,7 +367,7 @@
         "password-rules": "maxlength: 6; max-consecutive: 3; allowed: digit;"
     },
     "walkhighlands.co.uk": {
-        "password-rules": "required: lower; required: upper; required: digit; allowed: special; minlength: 9; maxlength: 15;"  
+        "password-rules": "minlength: 9; maxlength: 15; required: lower; required: upper; required: digit; allowed: special;"
     },
     "walmart.com": {
         "password-rules": "minlength: 6; maxlength: 12;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -366,6 +366,9 @@
     "vivo.com.br": {
         "password-rules": "maxlength: 6; max-consecutive: 3; allowed: digit;"
     },
+    "walkhighlands.co.uk": {
+        "password-rules": "required: lower; required: upper; required: digit; allowed: special; minlength: 9; maxlength: 15;"  
+    },
     "walmart.com": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },


### PR DESCRIPTION
Added a rule for https://www.walkhighlands.co.uk, using the requirements stated on their own account settings page (https://www.walkhighlands.co.uk/Forum/ucp.php?i=profile&mode=reg_details):

"Password must be between 9 and 15 characters long, must contain letters in mixed case and must contain numbers."

I have established through experimentation that beyond the minimum complexity requirements, the site also accepts all characters in the 'special' character class. I have not tested the full 'ascii-printable' or 'unicode' character sets, these may or may not be fully supported.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [ ] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
