### PR TITLE
Add costco.com password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -104,6 +104,9 @@
     "consorsfinanz.de": {
         "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit, [-.];"
     },
+    "costco.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; allowed: digit, [-!#$%&'()*+/:;=?@[^_`{|}~]];"
+    },
     "coursera.com": {
         "password-rules": "minlength: 8; maxlength: 72;"
     },


### PR DESCRIPTION
Adds a password rule for costco.com. The rule was discovered from the following link (you can navigate here without a Costco account): https://www.costco.com/ChangePassword

Screenshot:

![Screen Shot 2020-07-20 at 9 43 20 AM](https://user-images.githubusercontent.com/13814214/87945260-7ff1fc80-ca6e-11ea-966a-71565cbf1a31.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
