### PR TITLE
Add password rule for Anthem.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -32,6 +32,9 @@
     "angieslist.com": {
         "password-rules": "minlength: 6; maxlength: 15;"
     },
+    "anthem.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: upper, lower; required: digit; allowed: [!$*?@|]; max-consecutive: 3;"
+    },
     "apple.com": {
         "password-rules": "minlength: 8; maxlength: 63; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },
@@ -284,7 +287,7 @@
     },
     "powells.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [\"!@#$%^&*(){}[]];"
-    }, 
+    },
     "prepaid.bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: upper; required: lower; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Hey y'all, hope you're doing great this evening! I've attached a screenshot of what Anthem's JS-driven form validation yells at you with when you input an invalid password. Please let me know if there's any other info I should attach — thanks!

<img width="414" alt="Anthem.com's password requirements, screenshotted" src="https://user-images.githubusercontent.com/5892808/88007976-fec55480-cac3-11ea-873d-28615dd854a3.png">

**Edit**: Also, it looks like my auto-formatter deleted a stray whitespace character on line 287. I'm not sure if it should've been there in the first place, but I can re-add it if need be.
