### PR TITLE
Add target.com password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -345,6 +345,9 @@
     "sunlife.com": {
         "password-rules": "minlength: 8; maxlength: 10; required: digit; required: upper, lower;"
     },
+    "target.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: upper, lower; required: digit, [-!\"#$%&'()*+,./:;=?@[\\^_`{|}~];"
+    },
     "t-mobile.net": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },


### PR DESCRIPTION
Adds a password rule for target.com, discovered from their change password page (you can also view the rules when creating a new account):

![Screen Shot 2020-07-23 at 12 11 50 PM](https://user-images.githubusercontent.com/13814214/88311680-33f9be80-ccdf-11ea-88c4-9bf367f367fe.png)

In order to satisfy the `any 2 of <classes>` requirement I did:

```
required: lower, upper;
required: digit, [-~!@#$%^&*_+=`|/\(){}[:;"',.?];
```

If there's a better way to express that in the grammar please let me know! 🙂 

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
