### PR TITLE
Add Bancochile.cl

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -18,6 +18,7 @@
     "atlassian.com": "https://id.atlassian.com/manage-profile/security",
     "auction.co.kr": "https://memberssl.auction.co.kr/membership/MyInfo/MyInfo.aspx",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
+    "bancochile.cl": "https://portalpersonas.bancochile.cl/mibancochile-web/front/persona/index.html#/mi-perfil/datos-seguridad",
     "bbq-grill-world.de": "https://www.bbq-grill-world.de/customer/account/edit/changepass/1/",
     "berlet.de": "https://www.berlet.de/mein-konto.htm#my-account--edit-pass",
     "birkenstock.com": "https://www.birkenstock.com/profile",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -50,6 +50,9 @@
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"
     },
+    "bancochile.cl": {
+        "password-rules": "required: lower; required: upper; required: digit; minlength: 8; maxlength: 8;"
+    },
     "bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [-@#*()+={}/?~;,._];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -51,7 +51,7 @@
         "password-rules": "minlength: 6; maxlength: 14;"
     },
     "bancochile.cl": {
-        "password-rules": "required: lower; required: upper; required: digit; minlength: 8; maxlength: 8;"
+        "password-rules": "minlength: 8; maxlength: 8; required: lower; required: upper; required: digit;"
     },
     "bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [-@#*()+={}/?~;,._];"


### PR DESCRIPTION
<img width="1442" alt="Password requirements for bancochile.cl (in spanish)." src="https://user-images.githubusercontent.com/45631530/88961743-70936000-d273-11ea-9a83-c118545a41ce.png">

**Password Requirements (translated):**
- Must have 8 characters.
- You must create an alphanumeric password (letters and numbers, should contain at least one number, one lowercase letter, and one uppercase letter).
- Must be different from your last 4 registered passwords.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)