### PR TITLE
Password rules for multiple German email providers

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -192,6 +192,9 @@
     "github.com": {
         "password-rules": "minlength: 8; required: lower; required: digit; allowed: lower, upper, digit, [`!@#$%^&*()+~{}'\";:<>?];"
     },
+    "gmx.net": {
+        "password-rules": "minlength: 8; maxlength = 40; allowed: lower, upper, digit, [<=>-~!|()[]@#{}$%,.?^'&*_+`:;\"];"
+    },
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
     },
@@ -246,6 +249,9 @@
     "macys.com": {
         "password-rules": "minlength: 7; maxlength: 16; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*+`(){}[:;\"'<>?]];"
     },
+    "mailbox.org": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [!$\“%&/()=*+-#.,;:@?{}[]];"
+    },
     "makemytrip.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@$!%*#?&];"
     },
@@ -287,6 +293,9 @@
     },
     "planetary.org": {
         "password-rules": "minlength: 5; maxlength: 20; required: lower; required: upper; required: digit; allowed: ascii-printable;"
+    },
+    "posteo.de": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [-~!#$%&_+=|(){}[:;\“’<>,.? ]];"
     },
     "powells.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [\"!@#$%^&*(){}[]];"
@@ -389,6 +398,9 @@
     },
     "walmart.com": {
         "password-rules": "minlength: 6; maxlength: 12;"
+    },
+    "web.de": {
+        "password-rules": "minlength: 8; maxlength = 40; allowed: lower, upper, digit, [<=>-~!|()[]@#{}$%,.?^'&*_+`:;\"];"
     },
     "weibo.com": {
         "password-rules": "minlength: 6; maxlength: 16;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -193,7 +193,7 @@
         "password-rules": "minlength: 8; required: lower; required: digit; allowed: lower, upper, digit, [`!@#$%^&*()+~{}'\";:<>?];"
     },
     "gmx.net": {
-        "password-rules": "minlength: 8; maxlength = 40; allowed: lower, upper, digit, [<=>-~!|()[]@#{}$%,.?^'&*_+`:;\"];"
+        "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [<=>-~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
@@ -400,7 +400,7 @@
         "password-rules": "minlength: 6; maxlength: 12;"
     },
     "web.de": {
-        "password-rules": "minlength: 8; maxlength = 40; allowed: lower, upper, digit, [<=>-~!|()[]@#{}$%,.?^'&*_+`:;\"];"
+        "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [<=>-~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },
     "weibo.com": {
         "password-rules": "minlength: 6; maxlength: 16;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -250,7 +250,7 @@
         "password-rules": "minlength: 7; maxlength: 16; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*+`(){}[:;\"'<>?]];"
     },
     "mailbox.org": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [!$\“%&/()=*+-#.,;:@?{}[]];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [!$\"%&/()=*+-#.,;:@?{}[]];"
     },
     "makemytrip.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@$!%*#?&];"
@@ -295,7 +295,7 @@
         "password-rules": "minlength: 5; maxlength: 20; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },
     "posteo.de": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [-~!#$%&_+=|(){}[:;\“’<>,.? ]];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [-~!#$%&_+=|(){}[:;\"’<>,.? ]];"
     },
     "powells.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [\"!@#$%^&*(){}[]];"


### PR DESCRIPTION
### Mailbox.org: 
https://register.mailbox.org/en

<img width="520" alt="Your chosen password must be at least eight characters long, not be a word that can" src="https://user-images.githubusercontent.com/27491477/89036618-4b6b2400-d33d-11ea-93b1-e75733f97ecd.png">

### Posteo.de: 
https://posteo.de/en/help/what-are-the-minimu-requirements-for-a-posteo-password

<img width="466" alt="Minimum requirements for passwords" src="https://user-images.githubusercontent.com/27491477/89036710-735a8780-d33d-11ea-8de5-c3bf12ea526e.png">

Accepted symbols determined by testing.

### Web.de / Gmx.net

While web.de & gmx.net don't have a shared back-end, they're operated by the same parent company and are identical with respect to password requirements.

<img width="485" alt="Bildschirmfoto 2020-07-31 um 14 56 23" src="https://user-images.githubusercontent.com/27491477/89036998-0b587100-d33e-11ea-9eed-0e0b59d60706.png">
At least 8 characters, but no restrictions with respect to letters, numbers, ...

<img width="484" alt="Passwort wahlen" src="https://user-images.githubusercontent.com/27491477/89037043-21663180-d33e-11ea-8539-0bc94eeba205.png">
Max 40 characters

<img width="485" alt="Passwort i" src="https://user-images.githubusercontent.com/27491477/89037094-304ce400-d33e-11ea-850a-3178ca683e33.png">
No spaces at the beginning or end. Given we can't specify this so far I haven't included spaces in the password rule.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
