### PR TITLE
Add a rule for benjerry.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -56,6 +56,9 @@
     "bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [-@#*()+={}/?~;,._];"
     },
+    "benjerry.com": {
+        "password-rules": "required: upper; required: upper; required: digit; required: digit; required: special; required: special; allowed: lower;"
+    },
     "bhphotovideo.com": {
         "password-rules": "maxlength: 15;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="922" alt="Screen Shot 2020-08-02 at 2 24 51 PM" src="https://user-images.githubusercontent.com/234616/89437299-3eaf4d00-d6fc-11ea-8856-a935f015ebbc.png">

This is one of the more elaborate sets of rules I’ve seen. Conforming to them is very frustrating. I verified by hand that the website accepts all special characters.