### PR TITLE
Fix aliexpress.com rule to only allow alphanumeric passwords, with on…

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -12,7 +12,7 @@
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "aliexpress.com": {
-        "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit;"
+        "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit;"
     },
     "alliantcreditunion.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; allowed: [!#$*]; max-consecutive: 3;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -12,7 +12,7 @@
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "aliexpress.com": {
-        "password-rules": "minlength: 6; maxlength: 20;"
+        "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit;"
     },
     "alliantcreditunion.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; allowed: [!#$*]; max-consecutive: 3;"


### PR DESCRIPTION
…e each of lower, upper, and digit

Resolves #306.

<img width="305" alt="Screen Shot 2020-08-12 at 3 53 34 PM" src="https://user-images.githubusercontent.com/234616/90076213-ff609d80-dcb3-11ea-9f00-3c0f2c935677.png">

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.) — in issue filed
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
