### PR TITLE
Move hyphens to front of character class

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -196,7 +196,7 @@
         "password-rules": "minlength: 8; required: lower; required: digit; allowed: lower, upper, digit, [`!@#$%^&*()+~{}'\";:<>?];"
     },
     "gmx.net": {
-        "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [<=>-~!|()@#{}$%,.?^'&*_+`:;\"[]];"
+        "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
@@ -256,7 +256,7 @@
         "password-rules": "minlength: 7; maxlength: 16; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*+`(){}[:;\"'<>?]];"
     },
     "mailbox.org": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [!$\"%&/()=*+-#.,;:@?{}[]];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-!$\"%&/()=*+#.,;:@?{}[]];"
     },
     "makemytrip.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@$!%*#?&];"
@@ -406,7 +406,7 @@
         "password-rules": "minlength: 6; maxlength: 12;"
     },
     "web.de": {
-        "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [<=>-~!|()@#{}$%,.?^'&*_+`:;\"[]];"
+        "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },
     "weibo.com": {
         "password-rules": "minlength: 6; maxlength: 16;"


### PR DESCRIPTION
According to [the spec](https://github.com/whatwg/html/issues/3518), hyphens are only valid at the very beginning of a character class:

```
The dash character (-) is reserved as a special character. To list '-' as a literal character it must appear immediately after the opening square bracket '['.
```

Our parser over at @1Password caught a couple rules in the list that have the `-` in non-valid places, so I moved them to the start of the character class in this PR.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update