### PR TITLE
Add ezpassva.com password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -180,6 +180,9 @@
     "expertflyer.com": {
         "password-rules": "minlength: 5; maxlength: 16; required: lower, upper; required: digit;"
     },
+    "ezpassva.com": {
+        "password-rules": "required: lower; required: upper; required: digit; required: special; minlength: 8; maxlength: 16;"
+    },
     "fc2.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -181,7 +181,7 @@
         "password-rules": "minlength: 5; maxlength: 16; required: lower, upper; required: digit;"
     },
     "ezpassva.com": {
-        "password-rules": "required: lower; required: upper; required: digit; required: special; minlength: 8; maxlength: 16;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
     "fc2.com": {
         "password-rules": "minlength: 8; maxlength: 16;"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

Add password rule for ezpassva.com. The password rules are shown in the screenshot below.

<img width="689" alt="ezpassva password requirements" src="https://user-images.githubusercontent.com/8728716/90348721-319c3300-e005-11ea-939d-66d0d30b9cb0.png">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
