### PR TITLE
Remove `example.com`

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -170,10 +170,6 @@
     "ettoday.net": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },
-    "example.com": {
-        "exact-domain-match-only": true,
-        "password-rules": "allowed: lower,upper,special; minlength: 20;"
-    },
     "examservice.com.tw": {
         "password-rules": "minlength: 6; maxlength: 8;"
     },


### PR DESCRIPTION
As far as I know, `example.com` has no user accounts.

This was added as part of a bulk commit at https://github.com/apple/password-manager-resources/commit/f74c6d0c1488ed8653ebf81d9512a883f2055441#diff-7cad21d928bdc3c0285b83f770b77b1eR86

If this is an intentional test case, would it be possible to add a comment or a note in the repo explaining so?

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update
