### PR TITLE
Update change-password-URLs.json to include discord.com's password reset link

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -42,6 +42,7 @@
     "daum.net": "https://member.daum.net/change/password.daum",
     "delta.com": "https://www.delta.com/profile/basicInfo.action#editPassword",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",
+    "discord.com": "https://discord.com/settings/account",
     "disneyplus.com": "https://www.disneyplus.com/account/change-password",
     "dittomusic.com": "https://dashboard.dittomusic.com/account/password",
     "dropbox.com": "https://www.dropbox.com/account/security",


### PR DESCRIPTION
Note that https://discord.com/reset also works, but I chose /settings/account because It also allows for changing email and enabling 2FA

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
