### PR TITLE
Add speedway.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -103,6 +103,7 @@
     "shopback.co.kr": "https://www.shopback.co.kr/account/change-password",
     "sipgatebasic.de": "https://app.sipgatebasic.de/settings",
     "sonos.com": "https://www.sonos.com/myaccount/user/profile/",
+    "speedway.com": "https://www.speedway.com/my-account/security/passcode",
     "splunk.com": "https://www.splunk.com/my-account/#/profile-details",
     "stacksocial.com": "https://stacksocial.com/user?show=account-tab",
     "steampowered.com": "https://help.steampowered.com/wizard/HelpChangePassword?redir=store/account/",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -357,6 +357,9 @@
     "southwest.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^*(),.;:/\\];"
     },
+    "speedway.com": {
+        "password-rules": "required: digit; minlength: 4; maxlength: 8;"
+    },
     "spirit.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Tested at https://login.speedway.com/register

<img width="734" alt="Screenshot on 2020-08-27 at 06-38-16" src="https://user-images.githubusercontent.com/7596032/91432620-fdf4b080-e82f-11ea-83bc-bd5d548205e4.png">
