### PR TITLE
Add password rule for fedex.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -187,7 +187,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
     "fedex.com": {
-        "password-rules": "minlength: 8; required: digit; required: upper; required: lower; allowed: [-!@#$%^&*_+=`|(){}[:;<>,.?]];"
+        "password-rules": "minlength: 8; max-consecutive: 3; required: digit; required: upper; required: lower; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },
     "fc2.com": {
         "password-rules": "minlength: 8; maxlength: 16;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -186,6 +186,9 @@
     "ezpassva.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
+    "fedex.com": {
+        "password-rules": "minlength: 8; required: digit; required: upper; required: lower; allowed: [-!@#$%^&*_+=`|(){}[:;<>,.?]];"
+    },
     "fc2.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },


### PR DESCRIPTION
Adds a password rule for https://www.fedex.com. The rules were observed while signing up for a new account and can be seen in the following screenshot:

![Screen Shot 2020-08-28 at 8 48 06 AM](https://user-images.githubusercontent.com/13814214/91567306-eb06dc80-e912-11ea-9393-cdc428080222.png)

Note that their maxlength is 35 but I did not add this to the rule because they have the appropriate attribute in the HTML.

See also [this discussion thread](https://github.com/apple/password-manager-resources/pull/333#discussion_r479446322) for some additional things discovered that have been added to the rule.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
