### PR TITLE
Add password rule for hetzner.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -206,6 +206,9 @@
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
     },
+    "hetzner.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit, special;"
+    },
     "hilton.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
Adds a password rule for https://accounts.hetzner.com/signUp

Screenshot of their guidelines:

![Screen Shot 2020-08-31 at 11 14 09 AM](https://user-images.githubusercontent.com/13814214/91738058-f1e55780-eb7d-11ea-9dfd-b710846feb9e.png)

I tested some of the usual suspects for special characters that sites don't like (`'`, `"`, `<`, `>`, `space`), and their validator didn't complain, so it looks like they should be all good.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
