### PR TITLE
Add password rule for easycoop.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -155,6 +155,9 @@
     "dowjones.com": {
         "password-rules": "maxlength: 15;"
     },
+    "easycoop.com": {
+        "password-rules": "minlength: 8; required: upper; required: special; allowed: lower, digit;"
+    },
     "ecompanystore.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%*+.=@^_]; max-consecutive: 2;"
     },


### PR DESCRIPTION
Adds a password rule for https://easycoop.com/.

You can get to the signup page by entering this address:

```
Piazza del Colosseo
```

in the address field. Select the appropriate autocomplete suggestion. Then, enter `1` as the input for the smaller field on the right.

Screenshot of their guidelines:

![Screen Shot 2020-08-31 at 11 59 31 AM](https://user-images.githubusercontent.com/13814214/91741370-9cf81000-eb82-11ea-938f-d84d9be1b550.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
