### PR TITLE
Add rule for identitytheft.gov

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -230,6 +230,9 @@
     "id.sonyentertainmentnetwork.com": {
         "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
+    "identitytheft.gov": {
+        "password-rules": "allowed: upper,lower,digit,[!#%&*@^];"
+    },
     "idestination.info": {
         "password-rules": "maxlength: 15;"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
    - Testing will be completed by @rmondello
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
    - See issue #314 for more info
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

This PR resolves #314

As requested by @rmondello, here are 10 passwords generated by the [Password Rules Validation Tool](https://developer.apple.com/password-rules/) for testing the new rule with:

```
vynjow5gyccInigwam
somvokbyjqaz3hyCna
puqfAg7zovfigicfaz
pasxiwnabRoj3navvu
wYnrub0tykdenonwyc
pyjkefmyrxo7gaSrez
pinpyvtamcuhqytnA2
vywmezfirtAt9xohba
soxhA6dexwuqsogzib
Zomfyshiqwibmijfi9
```