### PR TITLE
Add password rule for guardiananytime.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -206,6 +206,9 @@
     "gmx.net": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },
+    "guardiananytime.com": {
+        "password-rules": "minlength: 8; maxlength: 50; max-consecutive: 2; required: lower; required: upper; required: digit, [-~!@#$%^&*_+=`|(){}[:;,.?]];"
+    },
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
     },


### PR DESCRIPTION
Adds a password rule for guardiananytime.com (go to https://www.guardianlife.com/login and work your way through the registration process for Guardian Anytime to find the page).

Here's a screenshot of their password rules:

![Screen Shot 2020-09-02 at 4 18 55 PM](https://user-images.githubusercontent.com/13814214/92035281-741b7a80-ed3c-11ea-8310-d4eed2757cd2.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
