### PR TITLE
Add password rule for store.nvidia.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -377,6 +377,9 @@
     "splunk.com": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower; required: upper; required: digit; required: [-!@#$%&*_+=<>];"
     },
+    "store.nvidia.com": {
+        "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [-!@#$%^*~:;&><[{}|_+=?]];"
+    },
     "sulamericaseguros.com.br": {
         "password-rules": "minlength: 6; maxlength: 6;"
     },


### PR DESCRIPTION
Adds a rule for https://store.nvidia.com.

This site is somewhat complicated to get to. You have to:

* Go to https://www.nvidia.com/en-us/shop/geforce
* Find an NVIDIA founder's edition card that's in-stock and choose "Add to cart"
* Go to the cart at the top right and choose "Checkout"
* You'll be redirected to a https://store.nvidia.com page
* Choose "Create account"
* The next page will have the password fields on it. You'll need to input fake data for the rest of the shipping form in order to see errors about the password, but you do not need to fill out the credit card number form

Screenshot of the rules:

<img width="560" alt="Screen Shot 2020-09-07 at 8 59 17 PM" src="https://user-images.githubusercontent.com/13814214/92531475-534f9b00-f1fc-11ea-96e6-e18ad835f513.png">

It doesn't seem like there's a nice way to express the "3 of 4" requirement here in password rules, so I just went ahead and required one character from all four classes.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
