### PR TITLE
Add password rule for nelnet.net

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -299,6 +299,9 @@
     "naver.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },
+    "nelnet.net": {
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit, [!@#$&*];"
+    },
     "netgear.com": {
         "password-rules": "minlength: 6; maxlength: 128; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()];"
     },


### PR DESCRIPTION
Adds a password rule for https://secure.nelnet.net/Registration/Index

Closes #343. See that issue for a screenshot of the rules.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
