### PR TITLE
Add password rule for hertz.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -212,6 +212,9 @@
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
     },
+    "hertz.com": {
+        "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower; required: upper; required: digit; required: [#$%^&!@];"
+    },
     "hetzner.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, special;"
     },


### PR DESCRIPTION
Adds a password rule for https://www.hertz.com/rentacar/member/enrollment/skinnyGold/fast

Screenshot of requirements:

![Screen Shot 2020-09-14 at 11 49 07 AM](https://user-images.githubusercontent.com/13814214/93109076-976df000-f681-11ea-96b3-4f3789c747ec.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
