### PR TITLE
`dumb-password-rules` Part 1

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -344,6 +344,9 @@
     "nelnet.net": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit, [!@#$&*];"
     },
+    "netflix.com": {
+        "password-rules": "required: lower, upper, digit; allowed: special; minlength: 4; maxlength: 60;"
+    },
     "netgear.com": {
         "password-rules": "minlength: 6; maxlength: 128; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -59,6 +59,9 @@
     "bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [-@#*()+={}/?~;,._];"
     },
+    "battle.net": {
+        "password-rules": "required: upper,lower; allowed: digit,special; minlength: 8; maxlength: 16;"
+    },
     "benjerry.com": {
         "password-rules": "required: upper; required: upper; required: digit; required: digit; required: special; required: special; allowed: lower;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -185,6 +185,9 @@
     "easycoop.com": {
         "password-rules": "minlength: 8; required: upper; required: special; allowed: lower, digit;"
     },
+    "easyjet.com": {
+        "password-rules": "required: lower; required: upper; required: digit; required: [-]; minlength: 6; maxlength: 20;"
+    },
     "ecompanystore.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%*+.=@^_]; max-consecutive: 2;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -5,6 +5,9 @@
     "1800flowers.com": {
         "password-rules": "minlength: 6; required: lower, upper; required: digit;"
     },
+    "admiral.com": {
+        "password-rules": "required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: upper,lower; minlength: 8;"
+    },
     "aetna.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: digit; max-consecutive: 2; allowed: lower, [-_&#@];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -65,6 +65,9 @@
     "benjerry.com": {
         "password-rules": "required: upper; required: upper; required: digit; required: digit; required: special; required: special; allowed: lower;"
     },
+    "bestbuy.com": {
+        "password-rules": "required: lower; required: upper; required: digit; required: special; minlength: 20;"
+    },
     "bhphotovideo.com": {
         "password-rules": "maxlength: 15;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -179,6 +179,9 @@
     "dowjones.com": {
         "password-rules": "maxlength: 15;"
     },
+    "ea.com": {
+        "password-rules": "required: lower; required: upper; required: digit; allowed: special; minlength: 8; maxlength: 16;"
+    },
     "easycoop.com": {
         "password-rules": "minlength: 8; required: upper; required: special; allowed: lower, digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -5,6 +5,9 @@
     "1800flowers.com": {
         "password-rules": "minlength: 6; required: lower, upper; required: digit;"
     },
+    "access.service.gov.uk": {
+        "password-rules": "required: lower; required: upper; required: digit; required: special; minlength: 10;"
+    },
     "admiral.com": {
         "password-rules": "required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: upper,lower; minlength: 8;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -494,6 +494,9 @@
     "walmart.com": {
         "password-rules": "allowed: lower, upper, digit, [-(~!@#$%^&*_+=`|(){}[:;\"'<>,.?]];"
     },
+    "waze.com": {
+        "password-rules": "required: upper,lower,digit; minlength: 8; maxlength: 64;"
+    },
     "web.de": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [ ] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
