### PR TITLE
Add support for Emblem Health Portals

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -329,6 +329,9 @@
     "portal.edd.ca.gov": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*@^];"
     },
+    "portals.emblemhealth.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()*+,./:;<>?@\^_`{|}~];"
+    },
     "posteo.de": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [-~!#$%&_+=|(){}[:;\"’<>,.? ]];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -330,7 +330,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*@^];"
     },
     "portals.emblemhealth.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()*+,./:;<>?@\^_`{|}~];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()*+,./:;<>?@\\\[\]^_`{|}~];"
     },
     "posteo.de": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [-~!#$%&_+=|(){}[:;\"’<>,.? ]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -330,7 +330,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*@^];"
     },
     "portals.emblemhealth.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()*+,./:;<>?@\\\[\]^_`{|}~];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()*+,./:;<>?@\\^_`{|}~[]];"
     },
     "posteo.de": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [-~!#$%&_+=|(){}[:;\"’<>,.? ]];"


### PR DESCRIPTION
Hi folks, here are the rules for portals.emblemhealth.com:

<img width="650" alt="Screen Shot 2020-09-18 at 8 32 31 AM" src="https://user-images.githubusercontent.com/662963/93597763-9098f300-f989-11ea-8ce2-3dfd7d640a86.png">


### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
