### PR TITLE
Add password rule for decluttr.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -137,6 +137,9 @@
     "darty.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
     },
+    "decluttr.com": {
+        "password-rules": "minlength: 8; maxlength: 45; required: lower; required: upper; required: digit;"
+    },
     "delta.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
Closes #348.

See the issue for a screenshot of the rules.

I experimented a bit to find the max length and it appears to be 45. You can confirm this by entering a valid password of length 45 and then adding a single letter or number and noting that it is no longer considered valid.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
