### PR TITLE
Add password rule for nowinstock.net

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -308,6 +308,9 @@
     "netgear.com": {
         "password-rules": "minlength: 6; maxlength: 128; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()];"
     },
+    "nowinstock.net": {
+        "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit;"
+    },
     "packageconciergeadmin.com": {
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },


### PR DESCRIPTION
Closes #350.

Screenshot of the rules can be found in the issue. The registration URL is https://www.nowinstock.net/users/register.php

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
