### PR TITLE
Add password rules for mygoodtogo.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -299,6 +299,9 @@
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
+    "mygoodtogo.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower, upper, digit;"
+    },
     "myhealthrecord.com": {
         "password-rules": "minlength: 8; maxlength: 20; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.!$*=];"
     },


### PR DESCRIPTION
Here are the password rules I found from mygoodtogo.com when creating an account:

<img width="959" alt="Screen Shot 2020-09-22 at 4 08 41 PM" src="https://user-images.githubusercontent.com/37423111/94076475-0bab4080-fdb2-11ea-9ed4-0b2e44e4e496.png">

I found the same rules when changing my password:

<img width="749" alt="Screen Shot 2020-09-22 at 4 08 07 PM" src="https://user-images.githubusercontent.com/37423111/94076544-3e553900-fdb2-11ea-9209-db4db7992243.png">

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
