### PR TITLE
Add shared credentials for mytotalconnectcomfort.com

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -210,6 +210,10 @@
         "mojang.com"
     ],
     [
+        "mytotalconnectcomfort.com",
+        "tccna.honeywell.com"
+    ],
+    [
         "nokia.com",
         "withings.com"
     ],


### PR DESCRIPTION
...with tccna.honeywell.com, a portal used for logging in with the Alexa skill

<img width="1316" alt="Screen Shot 2020-09-23 at 3 38 57 PM" src="https://user-images.githubusercontent.com/37423111/94082403-b5400100-fdb5-11ea-8523-712ce9ac9189.png">

<img width="1315" alt="Screen Shot 2020-09-23 at 3 39 19 PM" src="https://user-images.githubusercontent.com/37423111/94082398-b3763d80-fdb5-11ea-86c1-a2fd14b715c9.png">

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)
