### PR TITLE
adding comed.com password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -108,7 +108,7 @@
         "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; max-consecutive: 2;"
     },
     "comed.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?/\\]];"
     },
     "commerzbank.de": {
         "password-rules": "minlength: 5; maxlength: 8; required: lower, upper; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -107,6 +107,9 @@
     "comcastpaymentcenter.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; max-consecutive: 2;"
     },
+    "comed.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-];"
+    },
     "commerzbank.de": {
         "password-rules": "minlength: 5; maxlength: 8; required: lower, upper; required: digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->
![image](https://user-images.githubusercontent.com/1036984/94347299-7c439e80-fff8-11ea-8f8b-60542be70a9f.png)


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
