### PR TITLE
Add password rule for cardbenefitservices.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -80,6 +80,9 @@
     "capitalone.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower, upper; required: digit; allowed: [-_./\\@$*&!#];"
     },
+    "cardbenefitservices.com": {
+        "password-rules": "minlength: 7; maxlength: 100; required: lower, upper; required: digit;"
+    },
     "cb2.com": {
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },


### PR DESCRIPTION
Closes #360.

See the issue for a screenshot of the rules. You can attempt to create a new account with any email and a card number of `1111-2222-3333-4444` in order to get to the page with the rules.

I determined through experimentation that the maxlength is 100 (can be confirmed by entering a password of more than 100 chars).

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
