### PR TITLE
Add cigna.co.uk to password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -92,6 +92,9 @@
     "chase.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower, upper; required: digit; required: [!#$%+/=@~]; max-consecutive: 2;"
     },
+    "cigna.co.uk": {
+        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
+    },
     "cigna.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: digit; required: lower, upper; allowed: [_!.&@];"
     },


### PR DESCRIPTION
This is different from the (US?) cigna.com website rules because no symbols are allowed at all.

See screenshot:

![image](https://user-images.githubusercontent.com/74834/94600892-867ccb80-028a-11eb-9e07-ef7beb1c8a80.png)

Namely no special characters are allowed.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
