### PR TITLE
adding password rules for verizonwireless.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -444,7 +444,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [!@#$%^];"
     },
     "verizonwireless.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: digit; required: lower, upper;"
+        "password-rules": "minlength: 8; maxlength: 20; required: digit; required: lower, upper; allowed: unicode;"
     },
     "vetsfirstchoice.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [?!@$%^+=&];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -443,6 +443,9 @@
     "ventrachicago.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [!@#$%^];"
     },
+    "verizonwireless.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: digit; required: lower, upper;"
+    },
     "vetsfirstchoice.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [?!@$%^+=&];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
