### PR TITLE
Add WHB-Wiimmfi Quirk

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -312,6 +312,10 @@
         "wayfair.ca"
     ],
     [
+        "wiimmfi.de",
+        "wii-homebrew.com"
+    ],
+    [
         "wikipedia.org",
         "mediawiki.org",
         "wikibooks.org",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

As mentioned by Wiimmfi on https://wiimmfi.de/login as well as the [wiki page](https://wiiki.wii-homebrew.com/Wiimmfi_%28en%29/Portal#login) for login, Wii-Homebrew forum accounts are used for Wiimmfi site login, and thus the user accounts are shared.
