### PR TITLE
Add Wii-Homebrew PasswordChange URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -130,6 +130,7 @@
     "virginmobile.ca": "https://myaccount.virginmobile.ca/MyProfile/Details/EditProfile?editField=PASSWORD",
     "vivo.com.br": "https://meuvivo.vivo.com.br/meuvivo/appmanager/portal/fixo",
     "walgreens.com": "https://www.walgreens.com/account/user_and_password",
+    "wii-homebrew.com": "https://forum.wii-homebrew.com/index.php/AccountManagement/",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",
     "yahoo.com": "https://login.yahoo.com/account/change-password",
     "zeplin.io": "https://app.zeplin.io/profile/password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

Wii-Homebrew Board's change password URL is from the User drop-down -> Account Management; the user will see an "You are not authorised to view this page" if not logged in, which is a concern, but this still makes it easier to access the password change page rather than having to find the relevant page in their settings, especially when it's not named something simple as "Password".