### PR TITLE
Add a password-rules.json quirk for indochino.com #340

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -257,6 +257,9 @@
     "impots.gouv.fr": {
         "password-rules": "minlength: 12; maxlength: 128; required: lower; required: digit; allowed: [-!#$%&*+/=?^_'.{|}];"
     },
+    "indochino.com": {
+        "password-rules": "minlength: 6; maxlength: 15; required: upper; required: digit; allowed: lower,special;"
+    },
     "internationalsos.com": {
         "password-rules": "required: lower; required: upper; required: digit; required: [@#$%^&+=_];"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
