### PR TITLE
Update list of websites with shared credentials backend

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -314,10 +314,6 @@
         "disneyplus.com"
     ],
     [
-        "sodexo.com",
-        "sodexopass.fr"
-    ],
-    [
         "slcl.overdrive.com",
         "slcl.org"
     ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -293,10 +293,6 @@
         "getpocket.com"
     ],
     [
-        "pornhub.com",
-        "pornhubpremium.com"
-    ],
-    [
         "probikeshop.fr",
         "bikeshop.es",
         "probikeshop.it",

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -5,8 +5,67 @@
         "americanairlines.jp"
     ],
     [
+        "airfrance.com",
+        "flyingblue.com"
+    ],
+    [
         "aetna.com",
         "banneraetna.myplanportal.com"
+    ],
+    [
+        "airbnb.com.ar",
+        "airbnb.com.au",
+        "airbnb.at",
+        "airbnb.be",
+        "airbnb.com.bz",
+        "airbnb.com.bo",
+        "airbnb.com.br",
+        "airbnb.ca",
+        "airbnb.cl",
+        "airbnb.com.co",
+        "airbnb.co.cr",
+        "airbnb.cz",
+        "airbnb.dk",
+        "airbnb.com.ec",
+        "airbnb.com.sv",
+        "airbnb.fi",
+        "airbnb.fr",
+        "airbnb.de",
+        "airbnb.gr",
+        "airbnb.com.gt",
+        "airbnb.gy",
+        "airbnb.com.hn",
+        "airbnb.com.hk",
+        "airbnb.hu",
+        "airbnb.is",
+        "airbnb.co.in",
+        "airbnb.co.id",
+        "airbnb.ie",
+        "airbnb.it",
+        "airbnb.jp",
+        "airbnb.com.my",
+        "airbnb.com.mt",
+        "airbnb.mx",
+        "airbnb.nl",
+        "airbnb.co.nz",
+        "airbnb.com.ni",
+        "airbnb.no",
+        "airbnb.com.pa",
+        "airbnb.com.py",
+        "airbnb.com.pe",
+        "airbnb.pl",
+        "airbnb.pt",
+        "airbnb.ru",
+        "airbnb.com.sg",
+        "airbnb.co.kr",
+        "airbnb.es",
+        "airbnb.se",
+        "airbnb.ch",
+        "airbnb.com.tw",
+        "airbnb.com.tr",
+        "airbnb.co.uk",
+        "airbnb.com",
+        "airbnb.co.ve"
     ],
     [
         "alltrails.com",
@@ -17,6 +76,7 @@
         "amazon.com.au",
         "amazon.com.br",
         "amazon.ca",
+        "amazon.cn",
         "amazon.fr",
         "amazon.de",
         "amazon.in",
@@ -25,6 +85,7 @@
         "amazon.nl",
         "amazon.es",
         "amazon.com.tr",
+        "amazon.co.jp",
         "amazon.co.uk",
         "amazon.sg"
     ],
@@ -99,7 +160,8 @@
     [
         "citi.com",
         "citibank.com",
-        "citibankonline.com"
+        "citibankonline.com",
+        "citicards.com"
     ],
     [
         "comcast.net",
@@ -155,6 +217,10 @@
         "messenger.com"
     ],
     [
+        "fnac.com",
+        "fnacspectacles.com"
+    ],
+    [
         "fourleaf.net",
         "fourleaf.cl"
     ],
@@ -188,6 +254,10 @@
         "kcls.org"
     ],
     [
+        "laposte.fr",
+        "digiposte.fr"
+    ],
+    [
         "lookmark.io",
         "lookmark.link"
     ],
@@ -207,6 +277,7 @@
         "live.com",
         "microsoftonline.com",
         "office.com",
+        "outlook.com",
         "skype.com"
     ],
     [
@@ -230,11 +301,19 @@
         "getpocket.com"
     ],
     [
+        "pornhub.com",
+        "pornhubpremium.com"
+    ],
+    [
         "probikeshop.fr",
         "bikeshop.es",
         "probikeshop.it",
         "probikeshop.pt",
         "probikeshop.com"
+    ],
+    [
+        "royalbank.com",
+        "rbcroyalbank.com"
     ],
     [
         "scholarshare529.com",
@@ -248,7 +327,12 @@
     [
         "shopdisney.com",
         "go.com",
-        "disneyplus.com"
+        "disneyplus.com",
+        "disneystore.com"
+    ],
+    [
+        "sodexo.com",
+        "sodexopass.fr"
     ],
     [
         "slcl.overdrive.com",
@@ -325,6 +409,10 @@
         "wii-homebrew.com"
     ],
     [
+        "wellsfargo.com",
+        "wellsfargoadvisors.com"
+    ],
+    [
         "wikipedia.org",
         "mediawiki.org",
         "wikibooks.org",
@@ -363,5 +451,9 @@
     [
         "wsj.com",
         "dowjones.com"
+    ],
+    [
+        "yahoo.com",
+        "flickr.com"
     ]
 ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -160,8 +160,7 @@
     [
         "citi.com",
         "citibank.com",
-        "citibankonline.com",
-        "citicards.com"
+        "citibankonline.com"
     ],
     [
         "comcast.net",
@@ -254,10 +253,6 @@
         "kcls.org"
     ],
     [
-        "laposte.fr",
-        "digiposte.fr"
-    ],
-    [
         "lookmark.io",
         "lookmark.link"
     ],
@@ -277,7 +272,6 @@
         "live.com",
         "microsoftonline.com",
         "office.com",
-        "outlook.com",
         "skype.com"
     ],
     [
@@ -312,10 +306,6 @@
         "probikeshop.com"
     ],
     [
-        "royalbank.com",
-        "rbcroyalbank.com"
-    ],
-    [
         "scholarshare529.com",
         "secureaccountview.com"
     ],
@@ -327,8 +317,7 @@
     [
         "shopdisney.com",
         "go.com",
-        "disneyplus.com",
-        "disneystore.com"
+        "disneyplus.com"
     ],
     [
         "sodexo.com",

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -438,9 +438,5 @@
     [
         "wsj.com",
         "dowjones.com"
-    ],
-    [
-        "yahoo.com",
-        "flickr.com"
     ]
 ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -76,7 +76,6 @@
         "amazon.com.au",
         "amazon.com.br",
         "amazon.ca",
-        "amazon.cn",
         "amazon.fr",
         "amazon.de",
         "amazon.in",
@@ -85,7 +84,6 @@
         "amazon.nl",
         "amazon.es",
         "amazon.com.tr",
-        "amazon.co.jp",
         "amazon.co.uk",
         "amazon.sg"
     ],


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)
