### PR TITLE
Mention third-party parser implementations in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A rule that should only be applied to the exact domain stated as a key should ha
 
 An implementation of a parser for the Password Rules language that's written in JavaScript can be found in [`tools/PasswordRulesParser.js`](tools/PasswordRulesParser.js). It can be used as a reference implementation, interpreted in build systems to convert `data/password-rules.json` to an application-specific format, or interpreted at application runtime wherever it's possible to execute JavaScript (e.g. using the JavaScriptCore framework on Apple platforms).
 
-A third-party parser implementation is also available [here](https://github.com/1Password/password-rules-parser).
+A [third-party parser implementation](https://github.com/1Password/password-rules-parser) that's written in Rust is also available.
 
 ### Websites with Shared Credential Backends
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A rule that should only be applied to the exact domain stated as a key should ha
 
 An implementation of a parser for the Password Rules language that's written in JavaScript can be found in [`tools/PasswordRulesParser.js`](tools/PasswordRulesParser.js). It can be used as a reference implementation, interpreted in build systems to convert `data/password-rules.json` to an application-specific format, or interpreted at application runtime wherever it's possible to execute JavaScript (e.g. using the JavaScriptCore framework on Apple platforms).
 
+A third-party parser implementation is also available [here](https://github.com/1Password/password-rules-parser).
+
 ### Websites with Shared Credential Backends
 
 The file [`quirks/websites-with-shared-credential-backends.json`](quirks/websites-with-shared-credential-backends.json) contains a list of groups of websites that share the same credential backend and serve pages where users can sign in, accepting accounts from the others. For example, adding first.website and second.website means that first.website and second.website each serve a page (e.g. first.website/login and second.website/login) where the same accounts are valid for signing in, despite the different domains. It wouldn’t be appropriate to associate google.com.il to google.com because google.com.il redirects to accounts.google.com for sign-in, and google.com.il never serves a login page.


### PR DESCRIPTION
We made https://github.com/1Password/password-rules-parser public today :tada:; this PR mentions it in the README.

I'm not sure if any progress has been made on getting CI set up for the repo, but I'd love to help work some usage of our parser in there if possible when the time comes. It would be nice to check new rules against third-party implementations in addition to the reference parser. We've also put quite a bit of effort into outputting some clean, helpful errors that can be of use in deciphering syntax errors:

![Screen Shot 2020-11-09 at 11 38 27 AM](https://user-images.githubusercontent.com/13814214/98569291-22352a80-2280-11eb-8c48-1e67acf0aad6.png)

![Screen Shot 2020-11-09 at 11 38 37 AM](https://user-images.githubusercontent.com/13814214/98569305-25c8b180-2280-11eb-810e-cce6aa3b01d3.png)


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)