### PR TITLE
Add password rule for greatwestlife.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -239,6 +239,9 @@
     "google.com": {
         "password-rules": "minlength: 8; allowed: lower, upper, digit, [-!\"#$%&'()*+,./:;<=>?@[^_{|}~]];"
     },
+    "gwl.greatwestlife.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [-!#$%_=+<>];"
+    },
     "guardiananytime.com": {
         "password-rules": "minlength: 8; maxlength: 50; max-consecutive: 2; required: lower; required: upper; required: digit, [-~!@#$%^&*_+=`|(){}[:;,.?]];"
     },


### PR DESCRIPTION
Adds a password rule for https://gwl.greatwestlife.com/MyRegistration?lang=en_US

I scoped the rule to the `gwl` subdomain; as far as I can tell that seems to be the best thing to do, although it's difficult to find out for sure.

Screenshot of the rules on the site:

![Screen Shot 2020-11-11 at 12 04 57 PM](https://user-images.githubusercontent.com/13814214/98841461-23985b80-2416-11eb-8fd4-25cd6f275d69.png)

I omitted `maxlength` from the rule because the field on the site has the attribute on it already.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
