### PR TITLE
Shared credential backend update for Nokia Azure AD enterprise logins

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -198,7 +198,9 @@
     ],
     [
         "nokia.com",
-        
+        "alcatel-lucent.com",
+        "nsn-rdnet.net",
+        "nsn.com"
     ],
     [
         "optumrx.com",

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -198,7 +198,7 @@
     ],
     [
         "nokia.com",
-        "withings.com"
+        
     ],
     [
         "optumrx.com",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

Changes:
1. Removed withings.com from nokia.com array as it does not use a shared credential backend with the nokia.com Azure AD enterprise login:
<img width=50% height="50%" alt="Screenshot of withings.com login page" src="https://user-images.githubusercontent.com/10153929/99547221-42888600-29f2-11eb-9f27-7b0244dc2eb8.png">

2. Added websites to the nokia.com array that do have a shared credential backend with the nokia.com Azure AD enterprise login; namely alcatel-lucent.com, nsn-rdnet.net, nsn.com. (Alcatel-Lucent and NokiaSiemensNetworks have merged into Nokia, as have their enterprise systems and logins.)