### PR TITLE
Add a password rule for ring.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -398,6 +398,9 @@
     "rejsekort.dk": {
         "password-rules": "minlength: 7; maxlength: 15; required: lower; required: upper; required: digit;"
     },
+    "ring.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!@#$%^&*<>?];"
+    },
     "riteaid.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
Closes #379. https://site.ring.com/users/sign_up

Screenshots of rules on site:

![Screen Shot 2020-11-18 at 9 47 15 AM](https://user-images.githubusercontent.com/13814214/99551250-9e6af480-2989-11eb-856f-93c216a014a7.png)

![Screen Shot 2020-11-18 at 10 30 20 AM](https://user-images.githubusercontent.com/13814214/99551259-a165e500-2989-11eb-8e49-b1fc95b843fd.png)

Unfortunately, even though the bottom screenshot suggests that `-` is considered a valid symbol character, I found that passwords generated with `-` as the symbol were not accepted by the site. I therefore removed `-` from the custom character class.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
