### PR TITLE
add comdirect.de password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -125,6 +125,9 @@
     "comcastpaymentcenter.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; max-consecutive: 2;"
     },
+    "comdirect.de": {
+         "password-rules": "minlength: 6; maxlength: 6; required: digit;"
+    },
     "comed.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?/\\]];"
     },


### PR DESCRIPTION


add comdirect.de password rule

### Overall Checklist
- [ X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X ] The top-level JSON objects are sorted alphabetically
- [ X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ X] The given rule isn't particularly standard and obvious for password managers
- [X ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
![Screen Shot 2020-11-22 at 14 40 27](https://user-images.githubusercontent.com/12865086/99905446-05addf00-2cd1-11eb-8ee9-27a15d61114a.png)