### PR TITLE
Add portlandgeneral.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -89,6 +89,7 @@
     "playstation.com": "https://id.sonyentertainmentnetwork.com/id/management/#/p/security",
     "plex.tv": "https://app.plex.tv/desktop#!/account",
     "portal.edd.ca.gov": "https://portal.edd.ca.gov/WebApp/Profile/UpdatePassword",
+    "portlandgeneral.com": "https://new.portlandgeneral.com/secure/profile/change-password",
     "ppomppu.co.kr": "https://www.ppomppu.co.kr/myinfo/profile.php",
     "prolific.co": "https://app.prolific.co/account/general",
     "protonmail.com": "https://mail.protonmail.com/account",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -383,6 +383,9 @@
     "portals.emblemhealth.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()*+,./:;<>?@\\^_`{|}~[]];"
     },
+    "portlandgeneral.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower, upper, digit; allowed: [!#$%&*?@];"
+    },
     "posteo.de": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [-~!#$%&_+=|(){}[:;\"’<>,.? ]];"
     },


### PR DESCRIPTION
This PR adds password rules and a change password URL for [portlandgeneral.com](https://portlandgeneral.com).

<img width="900" alt="Screen Shot 2020-11-25 at 4 19 50 PM" src="https://user-images.githubusercontent.com/17183625/100294627-60576d00-2f55-11eb-87cc-8b246ef0599e.png">

While the rules from the screenshot don’t state that certain characters are not allowed, I was able to verify which of them cause validation to fail through trial and error:

<img width="940" alt="Screen Shot 2020-11-25 at 4 38 03 PM" src="https://user-images.githubusercontent.com/17183625/100294793-d0fe8980-2f55-11eb-8452-8c0ecf0d5f71.png">

<img width="940" alt="Screen Shot 2020-11-25 at 4 38 27 PM" src="https://user-images.githubusercontent.com/17183625/100294796-d4921080-2f55-11eb-9869-b9a620cf2128.png">


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
