### PR TITLE
Add wccls.org

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -506,6 +506,9 @@
     "waze.com": {
         "password-rules": "required: upper,lower,digit; minlength: 8; maxlength: 64;"
     },
+    "wccls.org": {
+        "password-rules": "minlength: 4; maxlength: 16; allowed: upper,lower,digit;"
+    },
     "web.de": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },


### PR DESCRIPTION
This PR adds password rules for [wccls.org](https://www.wccls.org).

<img width="550" alt="Screen Shot 2020-11-25 at 5 01 26 PM" src="https://user-images.githubusercontent.com/17183625/100295978-035db600-2f59-11eb-8405-2a08caecf3a0.png">

<img width="550" alt="Screen Shot 2020-11-25 at 5 01 06 PM" src="https://user-images.githubusercontent.com/17183625/100295979-0658a680-2f59-11eb-91f7-991edb71802b.png">


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
