### PR TITLE
Add vox media sites to shared credential backends

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -166,6 +166,13 @@
         "xfinity.com"
     ],
     [
+        "curbed.com",
+        "grubstreet.com",
+        "nymag.com",
+        "thecut.com",
+        "vulture.com"
+    ],
+    [
         "dinersclubnorthamerica.com",
         "dinersclubus.com"
     ],
@@ -185,6 +192,12 @@
     [
         "dropbox.com",
         "getdropbox.com"
+    ],
+    [
+        "eater.com",
+        "polygon.com",
+        "sbnation.com",
+        "theverge.com"
     ],
     [
         "ebay.at",


### PR DESCRIPTION
Adds various Vox Media sites to the shared credential backends list.

These sites share Vox Media credentials:

* https://www.theverge.com/
* https://www.eater.com/
* https://www.polygon.com/
* https://www.sbnation.com/

These sites share nymag credentials:

* https://nymag.com/
* https://www.curbed.com/
* https://www.vulture.com/
* https://www.thecut.com/
* https://www.grubstreet.com/

You can verify these all by going to their respective sign-in pages and noting the domain.

Normally these sites redirect to the shared backend domain for auth, which would mean these quirks wouldn't be necessary, but sometimes the sites provide auth popups that this quirk would help out with. For example, when logging in to comment on a Verge article in Firefox:

![Screen Shot 2020-12-10 at 1 13 43 PM](https://user-images.githubusercontent.com/13814214/101812587-8a7a6480-3ae9-11eb-91f9-92d8c2e8606a.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)