### PR TITLE
Added new password rules for Excelity, HSBC, Maybank

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -209,6 +209,9 @@
     "examservice.com.tw": {
         "password-rules": "minlength: 6; maxlength: 8;"
     },
+    "essportal.excelityglobal.com": {
+        "password-rules": "minlength: 6; maxlength: 8; allowed: lower, upper, digit;"
+     },
     "expertflyer.com": {
         "password-rules": "minlength: 5; maxlength: 16; required: lower, upper; required: digit;"
     },
@@ -266,6 +269,9 @@
     "hrblock.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [$#%!];"
     },
+    "hsbc.com.my": {
+        "password-rules": "minlength: 8; maxlength: 30; required: lower, digit; allowed: lower, upper, digit, [!$*-.=?@_'];"
+     },
     "hypovereinsbank.de": {
         "password-rules": "minlength: 6; maxlength: 10; required: lower, upper, digit; allowed: [!\"#$%&()*+:;<=>?@[{}~]];"
     },
@@ -326,6 +332,9 @@
     "marriott.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$!#&@?%=];"
     },
+    "maybank2u.com.my": {
+        "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 2; required: lower, upper, digit, special;"
+     },
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -203,15 +203,15 @@
     "epicmix.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },
+    "essportal.excelityglobal.com": {
+      "password-rules": "minlength: 6; maxlength: 8; allowed: lower, upper, digit;"
+    },
     "ettoday.net": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },
     "examservice.com.tw": {
         "password-rules": "minlength: 6; maxlength: 8;"
     },
-    "essportal.excelityglobal.com": {
-        "password-rules": "minlength: 6; maxlength: 8; allowed: lower, upper, digit;"
-     },
     "expertflyer.com": {
         "password-rules": "minlength: 5; maxlength: 16; required: lower, upper; required: digit;"
     },
@@ -270,7 +270,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [$#%!];"
     },
     "hsbc.com.my": {
-        "password-rules": "minlength: 8; maxlength: 30; required: lower, digit; allowed: lower, upper, digit, [!$*-.=?@_'];"
+        "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!$*.=?@_'];"
      },
     "hypovereinsbank.de": {
         "password-rules": "minlength: 6; maxlength: 10; required: lower, upper, digit; allowed: [!\"#$%&()*+:;<=>?@[{}~]];"
@@ -333,7 +333,7 @@
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$!#&@?%=];"
     },
     "maybank2u.com.my": {
-        "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 2; required: lower, upper, digit, special;"
+        "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 2; required: lower; required: upper; required: digit; required: special;"
      },
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -333,7 +333,7 @@
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$!#&@?%=];"
     },
     "maybank2u.com.my": {
-        "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 2; required: lower; required: upper; required: digit; required: special;"
+        "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 2; required: lower; required: upper; required: digit; required: [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?];"
      },
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"


### PR DESCRIPTION
### Changes made
Added new password rules for:
1. essportal.excelityglobal.com
<img width="848" alt="Screenshot 2020-12-11 at 5 05 08 PM" src="https://user-images.githubusercontent.com/10153929/101885580-43699d80-3bd5-11eb-8125-edaffea45dfe.png">

2. hsbc.com.my
<img width="848" alt="Screenshot 2020-12-11 at 5 08 40 PM" src="https://user-images.githubusercontent.com/10153929/101885596-48c6e800-3bd5-11eb-882f-b7c44cb08cff.png">

3. maybank2u.com.my
<img width="848" alt="Screenshot 2020-12-11 at 5 22 28 PM" src="https://user-images.githubusercontent.com/10153929/101885729-7744c300-3bd5-11eb-9874-021ca02ae7dc.png">

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
