### PR TITLE
Improved consistency of password-rules.json

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -66,7 +66,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, special;"
     },
     "benjerry.com": {
-        "password-rules": "required: upper; required: digit; required: special; allowed: lower;"
+        "password-rules": "required: upper; required: upper; required: digit; required: digit; required: special; required: special; allowed: lower;"
     },
     "bestbuy.com": {
         "password-rules": "minlength: 20; required: lower; required: upper; required: digit; required: special;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -60,7 +60,7 @@
         "password-rules": "minlength: 8; maxlength: 8; required: lower; required: upper; required: digit;"
     },
     "bankofamerica.com": {
-        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: upper; required: lower; required: digit; allowed: [-@#*()+={}/?~;,._];"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-@#*()+={}/?~;,._];"
     },
     "battle.net": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, special;"
@@ -393,7 +393,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [\"!@#$%^&*(){}[]];"
     },
     "prepaid.bankofamerica.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: upper; required: lower; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
     },
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -147,7 +147,7 @@
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },
     "cvs.com": {
-        "password-rules": "minlength: 8; maxlength: 25; required: lower, upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()];"
+        "password-rules": "minlength: 8; maxlength: 25; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
     },
     "dailymail.co.uk": {
         "password-rules": "minlength: 5; maxlength: 15;"
@@ -258,7 +258,7 @@
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"
     },
     "hotels.com": {
-        "password-rules": "minlength: 6; maxlength: 20; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@$!#()&^*%];"
+        "password-rules": "minlength: 6; maxlength: 20; required: digit; allowed: lower, upper, [@$!#()&^*%];"
     },
     "hotwire.com": {
         "password-rules": "minlength: 6; maxlength: 30; allowed: lower, upper, digit, [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?]];"
@@ -315,7 +315,7 @@
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
     "macys.com": {
-        "password-rules": "minlength: 7; maxlength: 16; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789~!@#$%^&*+`(){}[:;\"'<>?]];"
+        "password-rules": "minlength: 7; maxlength: 16; allowed: lower, upper, digit, [~!@#$%^&*+`(){}[:;\"'<>?]];"
     },
     "mailbox.org": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-!$\"%&/()=*+#.,;:@?{}[]];"
@@ -324,7 +324,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@$!%*#?&];"
     },
     "marriott.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$!#&@?%=];"
+        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; allowed: [$!#&@?%=];"
     },
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"
@@ -342,7 +342,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper, digit;"
     },
     "myhealthrecord.com": {
-        "password-rules": "minlength: 8; maxlength: 20; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.!$*=];"
+        "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
     },
     "naver.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
@@ -354,7 +354,7 @@
         "password-rules": "minlength: 4; maxlength: 60; required: lower, upper, digit; allowed: special;"
     },
     "netgear.com": {
-        "password-rules": "minlength: 6; maxlength: 128; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()];"
+        "password-rules": "minlength: 6; maxlength: 128; allowed: lower, upper, digit, [!@#$%^&*()];"
     },
     "nowinstock.net": {
         "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit;"
@@ -429,13 +429,13 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
     "sfwater.org": {
-        "password-rules": "minlength: 10; maxlength: 30; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%*()_+^}{:;?.];"
+        "password-rules": "minlength: 10; maxlength: 30; required: digit; allowed: lower, upper, [!@#$%*()_+^}{:;?.];"
     },
     "signin.ea.com": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
     "southwest.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^*(),.;:/\\];"
+        "password-rules": "minlength: 8; maxlength: 16; required: upper; required: digit; allowed: lower, [!@#$%^*(),.;:/\\];"
     },
     "speedway.com": {
         "password-rules": "minlength: 4; maxlength: 8; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -66,7 +66,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, special;"
     },
     "benjerry.com": {
-        "password-rules": "required: upper; required: upper; required: digit; required: digit; required: special; required: special; allowed: lower;"
+        "password-rules": "required: upper; required: digit; required: special; allowed: lower;"
     },
     "bestbuy.com": {
         "password-rules": "minlength: 20; required: lower; required: upper; required: digit; required: special;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -6,13 +6,13 @@
         "password-rules": "minlength: 6; required: lower, upper; required: digit;"
     },
     "access.service.gov.uk": {
-        "password-rules": "required: lower; required: upper; required: digit; required: special; minlength: 10;"
+        "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: special;"
     },
     "admiral.com": {
-        "password-rules": "required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: upper,lower; minlength: 8;"
+        "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"
     },
     "aetna.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: upper; required: digit; max-consecutive: 2; allowed: lower, [-_&#@];"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: upper; required: digit; allowed: lower, [-_&#@];"
     },
     "airasia.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
@@ -21,7 +21,7 @@
         "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit;"
     },
     "alliantcreditunion.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; allowed: [!#$*]; max-consecutive: 3;"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!#$*];"
     },
     "allianz.com.br": {
         "password-rules": "minlength: 4; maxlength: 4;"
@@ -39,7 +39,7 @@
         "password-rules": "minlength: 6; maxlength: 15;"
     },
     "anthem.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: upper, lower; required: digit; allowed: [!$*?@|]; max-consecutive: 3;"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!$*?@|];"
     },
     "apple.com": {
         "password-rules": "minlength: 8; maxlength: 63; required: lower; required: upper; required: digit; allowed: ascii-printable;"
@@ -60,16 +60,16 @@
         "password-rules": "minlength: 8; maxlength: 8; required: lower; required: upper; required: digit;"
     },
     "bankofamerica.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: upper; required: lower; required: digit; max-consecutive: 3; allowed: [-@#*()+={}/?~;,._];"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: upper; required: lower; required: digit; allowed: [-@#*()+={}/?~;,._];"
     },
     "battle.net": {
-        "password-rules": "required: upper,lower; allowed: digit,special; minlength: 8; maxlength: 16;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, special;"
     },
     "benjerry.com": {
         "password-rules": "required: upper; required: upper; required: digit; required: digit; required: special; required: special; allowed: lower;"
     },
     "bestbuy.com": {
-        "password-rules": "required: lower; required: upper; required: digit; required: special; minlength: 20;"
+        "password-rules": "minlength: 20; required: lower; required: upper; required: digit; required: special;"
     },
     "bhphotovideo.com": {
         "password-rules": "maxlength: 15;"
@@ -87,7 +87,7 @@
         "password-rules": "minlength: 8; maxlength: 16;"
     },
     "callofduty.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; max-consecutive: 2;"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: lower, upper; required: digit;"
     },
     "capitalone.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower, upper; required: digit; allowed: [-_./\\@$*&!#];"
@@ -102,16 +102,16 @@
         "password-rules": "minlength: 12; required: lower; required: upper; required: digit; required: [!#$%&*@^];"
     },
     "chase.com": {
-        "password-rules": "minlength: 8; maxlength: 32; required: lower, upper; required: digit; required: [!#$%+/=@~]; max-consecutive: 2;"
+        "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 2; required: lower, upper; required: digit; required: [!#$%+/=@~];"
     },
     "cigna.co.uk": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
     },
     "cigna.com": {
-        "password-rules": "minlength: 8; maxlength: 12; required: digit; required: lower, upper; allowed: [_!.&@];"
+        "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit; allowed: [_!.&@];"
     },
     "citi.com": {
-        "password-rules": "minlength: 6; maxlength: 50; required: lower, upper; required: digit; max-consecutive: 2; allowed: [_!@$]"
+        "password-rules": "minlength: 6; maxlength: 50; max-consecutive: 2; required: lower, upper; required: digit; allowed: [_!@$]"
     },
     "claimlookup.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@#$%^&+=!];"
@@ -123,7 +123,7 @@
         "password-rules": "minlength: 5; required: lower, upper; required: digit;"
     },
     "comcastpaymentcenter.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; max-consecutive: 2;"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2;required: lower, upper; required: digit;"
     },
     "comed.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?/\\]];"
@@ -180,16 +180,16 @@
         "password-rules": "maxlength: 15;"
     },
     "ea.com": {
-        "password-rules": "required: lower; required: upper; required: digit; allowed: special; minlength: 8; maxlength: 16;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
     },
     "easycoop.com": {
         "password-rules": "minlength: 8; required: upper; required: special; allowed: lower, digit;"
     },
     "easyjet.com": {
-        "password-rules": "required: lower; required: upper; required: digit; required: [-]; minlength: 6; maxlength: 20;"
+        "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: [-];"
     },
     "ecompanystore.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%*+.=@^_]; max-consecutive: 2;"
+        "password-rules": "minlength: 8; maxlength: 16; max-consecutive: 2; required: lower; required: upper; required: digit; required: [#$%*+.=@^_];"
     },
     "eddservices.edd.ca.gov": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; required: [!@#$%^&*()];"
@@ -219,7 +219,7 @@
         "password-rules": "minlength: 8; maxlength: 16;"
     },
     "fedex.com": {
-        "password-rules": "minlength: 8; max-consecutive: 3; required: digit; required: upper; required: lower; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
+        "password-rules": "minlength: 8; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },
     "fnac.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
@@ -228,10 +228,10 @@
         "password-rules": "minlength: 7; maxlength: 72;"
     },
     "girlscouts.org": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: lower, upper, digit, [$#!];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [$#!];"
     },
     "github.com": {
-        "password-rules": "minlength: 8; required: lower; required: digit; allowed: lower, upper, digit, [`!@#$%^&*()+~{}'\";:<>?];"
+        "password-rules": "minlength: 8; required: lower; required: digit; allowed: upper, [`!@#$%^&*()+~{}'\";:<>?];"
     },
     "gmx.net": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
@@ -261,7 +261,7 @@
         "password-rules": "minlength: 6; maxlength: 20; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@$!#()&^*%];"
     },
     "hotwire.com": {
-        "password-rules": "minlength: 6; maxlength: 30; allowed: upper, lower, digit, [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?]];"
+        "password-rules": "minlength: 6; maxlength: 30; allowed: lower, upper, digit, [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?]];"
     },
     "hrblock.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [$#%!];"
@@ -273,7 +273,7 @@
         "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
     "identitytheft.gov": {
-        "password-rules": "allowed: upper,lower,digit,[!#%&*@^];"
+        "password-rules": "allowed: lower, upper, digit, [!#%&*@^];"
     },
     "idestination.info": {
         "password-rules": "maxlength: 15;"
@@ -282,7 +282,7 @@
         "password-rules": "minlength: 12; maxlength: 128; required: lower; required: digit; allowed: [-!#$%&*+/=?^_'.{|}];"
     },
     "indochino.com": {
-        "password-rules": "minlength: 6; maxlength: 15; required: upper; required: digit; allowed: lower,special;"
+        "password-rules": "minlength: 6; maxlength: 15; required: upper; required: digit; allowed: lower, special;"
     },
     "internationalsos.com": {
         "password-rules": "required: lower; required: upper; required: digit; required: [@#$%^&+=_];"
@@ -300,7 +300,7 @@
         "password-rules": "minlength: 8; maxlength: 12;"
     },
     "ladwp.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: digit; allowed: upper, lower;"
+        "password-rules": "minlength: 8; maxlength: 20; required: digit; allowed: lower, upper;"
     },
     "leetchi.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
@@ -333,7 +333,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
     },
     "minecraft.com": {
-        "password-rules": "allowed: ascii-printable; minlength: 8; required: digit; required: upper, lower;"
+        "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: ascii-printable;"
     },
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
@@ -351,7 +351,7 @@
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit, [!@#$&*];"
     },
     "netflix.com": {
-        "password-rules": "required: lower, upper, digit; allowed: special; minlength: 4; maxlength: 60;"
+        "password-rules": "minlength: 4; maxlength: 60; required: lower, upper, digit; allowed: special;"
     },
     "netgear.com": {
         "password-rules": "minlength: 6; maxlength: 128; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()];"
@@ -363,7 +363,7 @@
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },
     "paypal.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: digit, [!@#$%^&*()]; required: lower, upper; max-consecutive: 3;"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower, upper; required: digit, [!@#$%^&*()];"
     },
     "payvgm.youraccountadvantage.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
@@ -438,7 +438,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: upper; required: digit; allowed: [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^*(),.;:/\\];"
     },
     "speedway.com": {
-        "password-rules": "required: digit; minlength: 4; maxlength: 8;"
+        "password-rules": "minlength: 4; maxlength: 8; required: digit;"
     },
     "spirit.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()];"
@@ -459,13 +459,13 @@
         "password-rules": "minlength: 6; maxlength: 6;"
     },
     "sunlife.com": {
-        "password-rules": "minlength: 8; maxlength: 10; required: digit; required: upper, lower;"
+        "password-rules": "minlength: 8; maxlength: 10; required: digit; required: lower, upper;"
     },
     "t-mobile.net": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },
     "target.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: upper, lower; required: digit, [-!\"#$%&'()*+,./:;=?@[\\^_`{|}~];"
+        "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit, [-!\"#$%&'()*+,./:;=?@[\\^_`{|}~];"
     },
     "telekom-dienste.de": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%&()*+,./<=>?@_{|}~];"
@@ -486,7 +486,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [!@#$%^];"
     },
     "verizonwireless.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: digit; required: lower, upper; allowed: unicode;"
+        "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; required: digit; allowed: unicode;"
     },
     "vetsfirstchoice.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [?!@$%^+=&];"
@@ -507,10 +507,10 @@
         "password-rules": "allowed: lower, upper, digit, [-(~!@#$%^&*_+=`|(){}[:;\"'<>,.?]];"
     },
     "waze.com": {
-        "password-rules": "required: upper,lower,digit; minlength: 8; maxlength: 64;"
+        "password-rules": "minlength: 8; maxlength: 64; required: lower, upper, digit;"
     },
     "wccls.org": {
-        "password-rules": "minlength: 4; maxlength: 16; allowed: upper,lower,digit;"
+        "password-rules": "minlength: 4; maxlength: 16; allowed: lower, upper, digit;"
     },
     "web.de": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
@@ -534,6 +534,6 @@
         "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
     },
     "zoom.us": {
-        "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; max-consecutive: 6;"
+        "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
     }
 }


### PR DESCRIPTION
A. Rearranged rules (when present) into the following order:
1. minlength
2. maxlength
3. max-consecutive
4. required
5. allowed

B. Rearranged "required: " and "allowed: " rule records in the following order:
lower > upper > digit > special.

C. Removed extraneous "allowed: " rules if they were already included as a "required: " rule.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
