### PR TITLE
Add Pinterest associated websites

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -295,7 +295,6 @@
         "pinterest.fr",
         "pinterest.de",
         "pinterest.es",
-        "pin.it",
         "pinterest.com.au",
         "pinterest.se",
         "pinterest.ph",

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -289,6 +289,31 @@
         "optum.com"
     ],
     [
+        "pinterest.com",
+        "pinterest.ca",
+        "pinterest.co.uk",
+        "pinterest.fr",
+        "pinterest.de",
+        "pinterest.es",
+        "pin.it",
+        "pinterest.com.au",
+        "pinterest.se",
+        "pinterest.ph",
+        "pinterest.ch",
+        "pinterest.com.mx",
+        "pinterest.dk",
+        "pinterest.pt",
+        "pinterest.ru",
+        "pinterest.it",
+        "pinterest.at",
+        "pinterest.jp",
+        "pinterest.cl",
+        "pinterest.ie",
+        "pinterest.co.kr",
+        "pinterest.nz",
+        "pintrest.com"
+    ],
+    [
         "pocket.com",
         "getpocket.com"
     ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -310,8 +310,7 @@
         "pinterest.cl",
         "pinterest.ie",
         "pinterest.co.kr",
-        "pinterest.nz",
-        "pintrest.com"
+        "pinterest.nz"
     ],
     [
         "pocket.com",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [ ] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)
