### PR TITLE
Add Eventbrite associated websites

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -210,6 +210,30 @@
         "ebay.vn"
     ],
     [
+        "eventbrite.at",
+        "eventbrite.be",
+        "eventbrite.ca",
+        "eventbrite.ch",
+        "eventbrite.cl",
+        "eventbrite.co",
+        "eventbrite.com",
+        "eventbrite.de",
+        "eventbrite.dk",
+        "eventbrite.es",
+        "eventbrite.fi",
+        "eventbrite.fr",
+        "eventbrite.hk",
+        "eventbrite.ie",
+        "eventbrite.in",
+        "eventbrite.it",
+        "eventbrite.my",
+        "eventbrite.nl",
+        "eventbrite.ph",
+        "eventbrite.pt",
+        "eventbrite.se",
+        "eventbrite.sg"
+    ],
+    [
         "facebook.com",
         "messenger.com"
     ],


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [ ] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)
