### PR TITLE
Add password rule for extraspace.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -215,6 +215,9 @@
     "expertflyer.com": {
         "password-rules": "minlength: 5; maxlength: 16; required: lower, upper; required: digit;"
     },
+    "extraspace.com": {
+        "password-rules": "minlength: 8; maxlength: 20; allowed: lower; required: upper, digit, [!#$%&*?@];"
+    },
     "ezpassva.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

extraspace.com doesn't accept a standard generated password from Safari.
![2020 12 14_09-15-01](https://user-images.githubusercontent.com/15079182/102566748-fbdf8780-4094-11eb-9895-b99e974a2b53.jpg)

The error message says a password should include an uppercase letter, a number, or a special character. The password in the picture has all three of those requirements, so that error message isn't telling the full story. 

I grabbed the validation regex for the password field from the HTML:
^(?=.*([A-Z]|\d|[$@$!%*#?&]))[A-Za-z\d$@$!%*#?&]{8,20}$

It looks like our generated password is being rejected because of the - character. The rule I added specifies allowed special characters for this site.

I tested this rule by downloading 10,000 rules from the Password Validation tool and applying the regex to each password in that file. All of the generated rules matched. 


