### PR TITLE
Add blizzard.com and battle.net as websites with shared credential backends

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -142,6 +142,10 @@
         "whistlerblackcomb.com"
     ],
     [
+        "battle.net",
+        "blizzard.com"
+    ],
+    [
         "boudinbakery.com",
         "boudincatering.com"
     ],


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

If you click "login" on blizzard.com, you will be directed to battle.net and then redirected to blizzard.com after you've successfully logged in. While I wasn't able to find a login page on blizzard.com, I was able to find a change password form. This form updates the credentials used to login on battle.net.
