### PR TITLE
Add secure.orclinic.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -100,6 +100,7 @@
     "rejsekort.dk": "https://selvbetjening.rejsekort.dk/CWS/CustomerManagement/ChangePassword",
     "santahelenasaude.com.br": "https://www.santahelenasaude.com.br/beneficiario/#/alterar-senha",
     "saturn.de": "https://www.saturn.de/webapp/wcs/stores/servlet/MultiChannelMAChangePassword",
+    "secure.orclinic.com": "https://secure.orclinic.com/portal/editprofile.aspx",
     "serasa.com.br": "https://www.serasa.com.br/meus-dados/alterar-senha",
     "shodan.io": "https://account.shodan.io/change_password",
     "shoop.de": "https://www.shoop.de/einstellungen/benutzerdaten",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -432,7 +432,7 @@
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit; allowed: [-!#$%&'()*,.:;=?^{}];"
     },
     "secure.orclinic.com": {
-        "password-rules": "minlength: 6; maxlength: 15; required: lower, digit; allowed: ascii-printable;"
+        "password-rules": "minlength: 6; maxlength: 15; required: lower; required: digit; allowed: ascii-printable;"
     },
     "secure-arborfcu.org": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -431,6 +431,9 @@
     "santander.de": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit; allowed: [-!#$%&'()*,.:;=?^{}];"
     },
+    "secure.orclinic.com": {
+        "password-rules": "minlength: 6; maxlength: 15; required: lower, digit; allowed: ascii-printable;"
+    },
     "secure-arborfcu.org": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

This PR adds `secure.orclinic.com`.

<img width="696" alt="Screen Shot 2021-01-14 at 8 42 27 PM" src="https://user-images.githubusercontent.com/17183625/104683915-be2e4880-56ac-11eb-9951-961a49bb5b49.png">


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
