### PR TITLE
Update change password URL for portlandgeneral.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -89,7 +89,7 @@
     "playstation.com": "https://id.sonyentertainmentnetwork.com/id/management/#/p/security",
     "plex.tv": "https://app.plex.tv/desktop#!/account",
     "portal.edd.ca.gov": "https://portal.edd.ca.gov/WebApp/Profile/UpdatePassword",
-    "portlandgeneral.com": "https://new.portlandgeneral.com/secure/profile/change-password",
+    "portlandgeneral.com": "https://portlandgeneral.com/secure/profile/change-password",
     "ppomppu.co.kr": "https://www.ppomppu.co.kr/myinfo/profile.php",
     "prolific.co": "https://app.prolific.co/account/general",
     "protonmail.com": "https://mail.protonmail.com/account",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

The URL `new.portlandgeneral.com` now redirects to `portlandgeneral.com`. It used to do the opposite.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state