### PR TITLE
Fix password rules for portlandgeneral.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -396,7 +396,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()*+,./:;<>?@\\^_`{|}~[]];"
     },
     "portlandgeneral.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower, upper, digit; allowed: [!#$%&*?@];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%&*?@];"
     },
     "posteo.de": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [-~!#$%&_+=|(){}[:;\"’<>,.? ]];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

This PR fixes a mistake I made in https://github.com/apple/password-manager-resources/pull/384. The password rules require lower, upper, _and_ a digit. But the way I originally wrote it would have accepted lower, upper, _or_ a digit, as explained by @Cldfire in https://github.com/apple/password-manager-resources/pull/409#discussion_r559053149.

![password-rules](https://user-images.githubusercontent.com/17183625/100294627-60576d00-2f55-11eb-87cc-8b246ef0599e.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
