### PR TITLE
Add password rules for hyresbostader.se

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -204,7 +204,7 @@
         "password-rules": "minlength: 8; maxlength: 16;"
     },
     "essportal.excelityglobal.com": {
-      "password-rules": "minlength: 6; maxlength: 8; allowed: lower, upper, digit;"
+        "password-rules": "minlength: 6; maxlength: 8; allowed: lower, upper, digit;"
     },
     "ettoday.net": {
         "password-rules": "minlength: 6; maxlength: 12;"
@@ -274,12 +274,12 @@
     },
     "hsbc.com.my": {
         "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!$*.=?@_'];"
-     },
+    },
     "hypovereinsbank.de": {
         "password-rules": "minlength: 6; maxlength: 10; required: lower, upper, digit; allowed: [!\"#$%&()*+:;<=>?@[{}~]];"
     },
     "hyresbostader.se": {
-        "password-rules": "minlength: 6; maxlength: 20; required: digit; required: upper,lower;"
+        "password-rules": "minlength: 6; maxlength: 20; required: lower, upper; required: digit;"
     },
     "id.sonyentertainmentnetwork.com": {
         "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
@@ -340,7 +340,7 @@
     },
     "maybank2u.com.my": {
         "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 2; required: lower; required: upper; required: digit; required: [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?];"
-     },
+    },
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -278,6 +278,9 @@
     "hypovereinsbank.de": {
         "password-rules": "minlength: 6; maxlength: 10; required: lower, upper, digit; allowed: [!\"#$%&()*+:;<=>?@[{}~]];"
     },
+    "hyresbostader.se": {
+        "password-rules": "minlength: 6; maxlength: 20; required: digit; required: upper,lower;"
+    },
     "id.sonyentertainmentnetwork.com": {
         "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },


### PR DESCRIPTION
The [signup page](https://www.hyresbostader.se/User/register.aspx) says: "Mellan 6 och 20 tecken, bokstäver och siffror". Translation: "Between 6 and 20 characters, letters and digits". I have verified that the page does seem to require both letters and numbers, but doesn't accept things like dashes (which is used in Safari by default).

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
