### PR TITLE
Add benefitslogin.discoverybenefits.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -20,6 +20,7 @@
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
     "bancochile.cl": "https://portalpersonas.bancochile.cl/mibancochile-web/front/persona/index.html#/mi-perfil/datos-seguridad",
     "bbq-grill-world.de": "https://www.bbq-grill-world.de/customer/account/edit/changepass/1/",
+    "benefitslogin.discoverybenefits.com": "https://benefitslogin.discoverybenefits.com/Profile/UpdatePassword.aspx",
     "berlet.de": "https://www.berlet.de/mein-konto.htm#my-account--edit-pass",
     "birkenstock.com": "https://www.birkenstock.com/profile",
     "blockchain.com": "https://login.blockchain.com/en/#/security-center/advanced",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -65,6 +65,9 @@
     "battle.net": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, special;"
     },
+    "benefitslogin.discoverybenefits.com": {
+        "password-rules": "minlength: 10; required: upper; required: digit; required: special; allowed: [!#$%&*?@];"
+    },
     "benjerry.com": {
         "password-rules": "required: upper; required: upper; required: digit; required: digit; required: special; required: special; allowed: lower;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -66,7 +66,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, special;"
     },
     "benefitslogin.discoverybenefits.com": {
-        "password-rules": "minlength: 10; required: upper; required: digit; required: special; allowed: [!#$%&*?@];"
+        "password-rules": "minlength: 10; required: upper; required: digit; required: [!#$%&*?@]; allowed: lower;"
     },
     "benjerry.com": {
         "password-rules": "required: upper; required: upper; required: digit; required: digit; required: special; required: special; allowed: lower;"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

<img width="984" alt="Screen Shot 2021-01-24 at 4 53 34 PM" src="https://user-images.githubusercontent.com/17183625/105661969-b042a980-5e9c-11eb-9c49-a4a82e97ea97.png">


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
