### PR TITLE
Add password rules for vanguardinvestor.co.uk

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -500,6 +500,9 @@
     "vanguard.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },
+    "vanguardinvestor.co.uk": {
+        "password-rules": "minlength: 8; maxlength: 50; required: lower; required: upper; required: digit; required: digit;"
+    },
     "ventrachicago.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [!@#$%^];"
     },


### PR DESCRIPTION
Closes #415. See the issue for a screenshot of the site's rules.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/) _(I can't get to the page in question)_
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
