### PR TITLE
Add password rule and change password URL for astonmartinf1.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -15,6 +15,7 @@
     "anatel.gov.br": "https://apps.anatel.gov.br/AnatelConsumidor/ConsumidorEditar.aspx",
     "arlt.com": "https://www.arlt.com/mein-passwort/",
     "arxiv.org": "https://arxiv.org/user/change_own_password",
+    "astonmartinf1.com": "https://auth.astonmartinf1.com/Dashboard/ChangePassword",
     "atlassian.com": "https://id.atlassian.com/manage-profile/security",
     "auction.co.kr": "https://memberssl.auction.co.kr/membership/MyInfo/MyInfo.aspx",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -48,7 +48,7 @@
         "password-rules": "minlength: 6; maxlength: 19;"
     },
     "astonmartinf1.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%&()*+/:;<=>@[\^_`|~]];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
     },
     "autify.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -47,6 +47,9 @@
     "artscyclery.com": {
         "password-rules": "minlength: 6; maxlength: 19;"
     },
+    "astonmartinf1.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit;"
+    },
     "autify.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -48,7 +48,7 @@
         "password-rules": "minlength: 6; maxlength: 19;"
     },
     "astonmartinf1.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%&()*+/:;<=>@[\^_`|~]];"
     },
     "autify.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="831" alt="screenshot" src="https://user-images.githubusercontent.com/5855073/106365657-9241d280-62fc-11eb-8439-72d61bff55a4.png">
