### PR TITLE
Special case: Send to OneNote

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -321,7 +321,8 @@
         "live.com",
         "microsoftonline.com",
         "office.com",
-        "skype.com"
+        "skype.com",
+        "onenote.com"
     ],
     [
         "minecraft.net",


### PR DESCRIPTION
While logging into Microsoft services mostly happens on live.com I've just discovered that if you're setting up the "send to OneNote" feature via [https://www.onenote.com/EmailToOneNote](https://www.onenote.com/EmailToOneNote), the first step of the login procedure (entering the e-mail address) happens one onenote.com.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)
