### PR TITLE
Add shared backend for Logitech's LOGI ID

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -304,6 +304,14 @@
         "myliebherr.com"
     ],
     [
+        "logitech.com",
+        "logitechg.com",
+        "logi.com",
+        "astrogaming.com",
+        "ultimateears.com"
+
+    ],
+    [
         "lookmark.io",
         "lookmark.link"
     ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -309,7 +309,6 @@
         "logi.com",
         "astrogaming.com",
         "ultimateears.com"
-
     ],
     [
         "lookmark.io",


### PR DESCRIPTION
Logitech's various properties share a single login system served from different domains, as documented [here](https://www.logitech.com/en-us/promo/logi-id.html).

Verified by signing up for a new account at id.logi.com (with a unique password), and was able to successfully login at all listed domains.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)
