### PR TITLE
Add ototoy.jp password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -380,6 +380,9 @@
     "nowinstock.net": {
         "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit;"
     },
+    "ototoy.jp": {
+        "password-rules": "minlength: 8; allowed: upper,lower,digit,[- .=_];"
+    },
     "packageconciergeadmin.com": {
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

![8FD2DE68-D901-404B-988F-CDE6D6872501](https://user-images.githubusercontent.com/5276387/107737295-135a8a00-6d3f-11eb-8b53-2cdc2192215a.png)

I have tried 6 passwords generated by the rules validation tool, and they all passed form validation.