### PR TITLE
add password rules for qdosstatusreview.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -423,7 +423,7 @@
         "password-rules": "minlength: 6; maxlength: 16;"
     },
     "qdosstatusreview.com": {
-      "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&@^];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&@^];"
     },
     "rejsekort.dk": {
         "password-rules": "minlength: 7; maxlength: 15; required: lower; required: upper; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -422,6 +422,9 @@
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },
+    "qdosstatusreview.com": {
+      "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&@^];"
+    },
     "rejsekort.dk": {
         "password-rules": "minlength: 7; maxlength: 15; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->
### Documentation
The website https://www.qdosstatusreview.com/ shows the current requirements when setting up a password; passwords suggested by Safari consistently fail the last requirement:

![Screenshot 2021-02-12 at 13 56 49](https://user-images.githubusercontent.com/7751234/107777872-4dc22800-6d3b-11eb-8149-9af163ed3c55.png)

Note that the backslash doesn't really seem to be a valid character, it seems it was included as a way to escape $ an ^ (presumably this was copy-pasted from somewhere else). I verified this by trying to use a password that would contain backslash as the only "special character", but this was rejected. Similarly, space is included in the description but it is not considered a valid character when attempting. Finally, @ is duplicated, I've only included it once in the rules.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [ ] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
