### PR TITLE
Added mintmobile.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -356,6 +356,9 @@
     "minecraft.com": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: ascii-printable;"
     },
+    "mintmobile.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
+    },
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update  

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

### Research
A screenshot is attached with the error message shown when attempting an invalid password. The `maxlength: 20` is not clear anywhere on the website or via the HTML tags. It took some trial-and-error to figure out that requirement. I have tested several passwords with the updated password-rules.json pattern successfully.

![mintmobile com password error](https://user-images.githubusercontent.com/3170382/110387393-c3f63980-801e-11eb-8087-9fd6b0c4b574.png)
