### PR TITLE
Update american express password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -27,7 +27,7 @@
         "password-rules": "minlength: 4; maxlength: 4;"
     },
     "americanexpress.com": {
-        "password-rules": "minlength: 8; maxlength: 20;"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [-%&_?#=];"
     },
     "anatel.gov.br": {
         "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit;"


### PR DESCRIPTION
Updates the password rules for american express to be in line with their documentation: https://www.americanexpress.com/en-us/banking/online-savings/faq/password-requirements/

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
