### PR TITLE
Add password rules for la-z-boy.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -320,6 +320,9 @@
     "ladwp.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: digit; allowed: lower, upper;"
     },
+    "la-z-boy.com": {
+        "password-rules": "minlength: 6; maxlength: 15; required: lower, upper; required: digit;"
+    },
     "leetchi.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },


### PR DESCRIPTION
Closes #435.

See the issue for documentation of the site's password rules.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
