### PR TITLE
quirks/password-rules: add mysubaru.com due to maxlength: 15

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -371,6 +371,9 @@
     "myhealthrecord.com": {
         "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
     },
+    "mysubaru.com": {
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"
+    },
     "naver.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },


### PR DESCRIPTION
This adds password generation quirks for the rules hard-coded by the domain mysubaru.com.

Per the text of their site at https://www.mysubaru.com/profile/securitySettings.html#changePassword as of the time of this submission:

> Password must contain the following:
> 
> Between 8 and 15 characters long
> Uppercase characters (A-Z)
> Lowercase characters (a-z)
> Numbers (0-9)
> No spaces allowed
> Special characters can be included (@ ! # $ ^ % * ( ) + = - \ ; , . / : ? ~`)
> Cannot be your existing password

I believe that the primary non-obvious rule here is that they limit passwords to 15 characters, which I discovered when Safari for macOS generated an invalid password.

I tested a few random samples from the set of 100 using the change form above to ensure that they complied. When the password is rejected, the site shows the text "Password does not meet requirements" (in Safari for macOS).

ps. In the process of creating this pull request, I found a documentation gap: CONTRIBUTING.md (#contributing-a-rule) doesn't address the circumstance where a [character class] contains a backslash, such as shown at MySubaru's site. I encourage assessing the Password Rules Validation Tool's handling of backslashes to ensure that the "Rules formatted for" input fields are handling backslashes to your satisfaction.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
