### PR TITLE
quirks/password-rules: add ajisushionline.com due to refusing hyphens

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -17,6 +17,9 @@
     "airasia.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
+    "ajisushionline.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [ !#$%&*?@];"
+    },
     "aliexpress.com": {
         "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit;"
     },


### PR DESCRIPTION
This adds password generation quirks for the rules hard-coded by the domain ajisushionline.com.

Per the javascript inspector of their website's change-password functionality at https://ajisushionline.com/Users/myProfile/XXXX/YYYY (obscured), and their error messages, their rules are generally normal with the exception of not allowing hyphens, which breaks Safari password generation:

```
        jQuery.validator.addMethod("passw", function (pass, element) {
            pass = pass.replace(/\s+/g, "");
            return this.optional(element) || pass.length > 7 &&
                    pass.match(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[A-Za-z\d$@$!%*#?& ]{8,}$/);
        }, "Atleast one digit, one upper and one lower case letter");
```

I generated and tested a few passwords to confirm that the rule in this pull request, generated using the Password Rules Validation Tool, are accepted by their site.

ps. The site is operated by iorderfoods.com, so it's possible there could be other sites sharing the above regular expression.

<img width="1326" alt="ajisushionline.com change password screen" src="https://user-images.githubusercontent.com/92684/112278603-41859080-8c40-11eb-9088-f3d6ccfb3d08.png">

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
