### PR TITLE
Update password rules for wsj.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -576,7 +576,7 @@
         "password-rules": "minlength: 6; maxlength: 16;"
     },
     "wsj.com": {
-        "password-rules": "maxlength: 15;"
+        "password-rules": "minlength: 5; maxlength: 15; required: digit; allowed: lower, upper, [-~!@#$^*_=`|(){}[:;\"'<>,.?]];"
     },
     "www4.irs.gov": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [!#$%&*@];"


### PR DESCRIPTION
Updates the password rules for wsj.com, closing #441.

A good page to see the rules and test generated passwords on is https://register.wsj.com/register.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)