### PR TITLE
Add password rules for successfactors.eu

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -506,6 +506,9 @@
     "store.steampowered.com": {
         "password-rules": "minlength: 6; required: lower; required: upper; required: digit; allowed: [~!@#$%^&*];"
     },
+    "successfactors.eu": {
+        "password-rules": "minlength: 8; maxlength: 18; required: lower; required: upper; required: digit,[-!\"#$%&'()*+,.:;<=>?@[^_`{|}~]];"
+    },
     "sulamericaseguros.com.br": {
         "password-rules": "minlength: 6; maxlength: 6;"
     },


### PR DESCRIPTION
This the job applications website used by the European Space Agency (ESA). You need the right link to be
able to access the account creation page:

https://career2.successfactors.eu/career?company=esa&site=&lang=en_GB&requestParams=H9TUb%2fvf%2fBAA758tHFQhxmi1VHR42m1Qy0pDQQyNrbUvUYvgzl8o7W0LggsfSOsFBUF04%2bKaTmM7%0aZZyZzqS2IvhF%2bhHiF%2bjSHxAX%2foPT6qIXDCSLnJOTkzx9Q847qAzxDqtjlqp6jH5wijaX%2f3h53bp%2b%0ay0KmDSVlsNdGwcbFUOSBIz8wqje1e%2fswi9VJIdSNkCWGZS%2bZxg42r07mqgp1v3rOTur%2b7vP75efX%0a9kMnAzC1gb7EAAwFoSRpjnvjETxC9rdfGJqujybUZagIdEQuCZ3E0SiRKWKuHjVaLYayN0KiOrBW%0a3afwG1SeAh7Gz6QlJTUt4itH0pFghjVhnCOFLI1O0mbKUbNea0Q7zUatHojSx5rJaVQXntx%2fy%2fLC%0a3FrUKSNZ8shQ%2fDtG%2b0VsfXYbButSzPeHN87%2blpImnXQOpz9DSXmX&login_ns=register&career_ns=job%5fapplication&career_job_req_id=12355&jobPipeline=Direct&_s.crb=3azfiNwHLDN8iRzm0X0HJE9vqstx4eTlHfZjODdbaso%3d

The password rules stated on the website are:

- Password must be at least 8 characters long.
- Password must not be longer than 18 characters.
- Password must contain at least one upper case and one lower case letter.
- Password must contain at least one number or punctuation character.
- Password must not contain space or unicode characters.

I've tried a few generated passwords generated by these rules and they all seem to work.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [ ] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
