### PR TITLE
Update password rules for cigna.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -117,7 +117,7 @@
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
     },
     "cigna.com": {
-        "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit; allowed: [_!.&@];"
+        "password-rules": "minlength: 8; maxlength: 12; required: upper; required: digit; required: [_!.&@]; allowed: lower;"
     },
     "citi.com": {
         "password-rules": "minlength: 6; maxlength: 50; max-consecutive: 2; required: lower, upper; required: digit; allowed: [_!@$]"


### PR DESCRIPTION
Closes #443.

I've adjusted the rule for both the new symbol requirement and the changed letter requirements, based on the screenshot.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
