### PR TITLE
feat(change): add change password url for myaccount.google

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -78,6 +78,7 @@
     "minecraft.net": "https://www.minecraft.net/profile",
     "mojang.com": "https://www.minecraft.net/profile",
     "myaccount.ea.com": "https://myaccount.ea.com/cp-ui/security/index",
+    "myaccount.google.com": "https://myaccount.google.com/signinoptions/password",
     "naver.com": "https://nid.naver.com/user2/help/myInfo.nhn?m=viewChangePasswd",
     "netflix.com": "https://www.netflix.com/password",
     "news.ycombinator.com": "https://news.ycombinator.com/changepw",


### PR DESCRIPTION
Redirects to the change password form and requires login each time, even if the user is already logged in

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
