### PR TITLE
Fix failing linting for password rules sort order

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -254,11 +254,11 @@
     "google.com": {
         "password-rules": "minlength: 8; allowed: lower, upper, digit, [-!\"#$%&'()*+,./:;<=>?@[^_{|}~]];"
     },
-    "gwl.greatwestlife.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [-!#$%_=+<>];"
-    },
     "guardiananytime.com": {
         "password-rules": "minlength: 8; maxlength: 50; max-consecutive: 2; required: lower; required: upper; required: digit, [-~!@#$%^&*_+=`|(){}[:;,.?]];"
+    },
+    "gwl.greatwestlife.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [-!#$%_=+<>];"
     },
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -320,11 +320,11 @@
     "klm.com": {
         "password-rules": "minlength: 8; maxlength: 12;"
     },
-    "ladwp.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: digit; allowed: lower, upper;"
-    },
     "la-z-boy.com": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower, upper; required: digit;"
+    },
+    "ladwp.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: digit; allowed: lower, upper;"
     },
     "leetchi.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -461,14 +461,14 @@
     "santander.de": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit; allowed: [-!#$%&'()*,.:;=?^{}];"
     },
+    "secure-arborfcu.org": {
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
+    },
     "secure.orclinic.com": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower; required: digit; allowed: ascii-printable;"
     },
     "secure.wa.aaa.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: ascii-printable;"
-    },
-    "secure-arborfcu.org": {
-        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
     },
     "sephora.com": {
         "password-rules": "minlength: 6; maxlength: 12;"


### PR DESCRIPTION
The password rules for `guardiananytime`, `la-z-boy`, and `secure-arborfcu` we're all out of order causing the linting job to fail when branches were pushed and pull requests were opened.