### PR TITLE
transferwise.com is now wise.com

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -539,6 +539,10 @@
         "luxilon.com"
     ],
     [
+        "wise.com",
+        "transferwise.com"
+    ],
+    [
         "worldlink.com.np",
         "nettv.com.np"
     ],


### PR DESCRIPTION
More details: https://wise.com/help/articles/4LB2UIQjHBGiof7UBipZpU/how-will-the-change-to-wise-affect-my-login-account-details-and-card

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [ ] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

The service has changed their domain as explained here:
https://wise.com/gb/blog/world-meet-wise
