### PR TITLE
Update password rules for crateandbarrel.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -153,7 +153,7 @@
         "password-rules": "minlength: 8; maxlength: 72;"
     },
     "crateandbarrel.com": {
-        "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
+        "password-rules": "minlength: 9; maxlength: 64; required: lower; required: upper; required: digit; required: [!\"#$%&()*,.:<>?@^_{|}];"
     },
     "cvs.com": {
         "password-rules": "minlength: 8; maxlength: 25; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"


### PR DESCRIPTION
I've updated the rule based off the site's requirements. See: https://www.crateandbarrel.com/account/create-account

<img width="337" alt="image" src="https://user-images.githubusercontent.com/7517009/116930626-ff337400-ac2d-11eb-9354-f33565026a1f.png">

Note that the symbols mentioned in the screenshot aren't the only characters supported, which is why the required special symbols rule contains extra characters.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)