### PR TITLE
Add password rules for fuelrewards.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -242,6 +242,9 @@
     "fnac.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
     },
+    "fuelrewards.com": {
+        "password-rules": "minlength: 8; maxlength: 16; allowed: upper,lower,digit,[!#$%@];"
+    },
     "getflywheel.com": {
         "password-rules": "minlength: 7; maxlength: 72;"
     },


### PR DESCRIPTION
I've added the rule based off the site's requirements.

![image](https://user-images.githubusercontent.com/7517009/117058349-83e4c780-acec-11eb-9a3a-ba1a87163276.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)