### PR TITLE
Add password rules for mlb.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -378,7 +378,7 @@
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
     },
     "mlb.com": {
-        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [-];"
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [-];"
     },
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -377,6 +377,9 @@
     "mintmobile.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
     },
+    "mlb.com": {
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [-];"
+    },
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -378,7 +378,7 @@
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
     },
     "mlb.com": {
-        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [-];"
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!\"#$%&'()*+,./:;<=>?[\\^_`{|}~]];"
     },
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"


### PR DESCRIPTION
I've added the rule based off the site's requirements.

![image](https://user-images.githubusercontent.com/7517009/117060738-433a7d80-acef-11eb-8102-220ddecc6312.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)