### PR TITLE
Add password rules for cox.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -152,6 +152,9 @@
     "coursera.com": {
         "password-rules": "minlength: 8; maxlength: 72;"
     },
+    "cox.com": {
+        "password-rules": "minlength: 8; maxlength: 24; required: digit; required: upper,lower; allowed: [!#$%()*@^];"
+    },
     "crateandbarrel.com": {
         "password-rules": "minlength: 9; maxlength: 64; required: lower; required: upper; required: digit; required: [!\"#$%&()*,.:<>?@^_{|}];"
     },


### PR DESCRIPTION
I've added the rule based off the site's requirements.

<img width="764" alt="Screen Shot 2021-05-10 at 7 43 43 AM" src="https://user-images.githubusercontent.com/7517009/117876031-de43d200-b270-11eb-8173-62e09e07afae.png">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)