### PR TITLE
Add password change URL for bandcamp.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -20,6 +20,7 @@
     "auction.co.kr": "https://memberssl.auction.co.kr/membership/MyInfo/MyInfo.aspx",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
     "bancochile.cl": "https://portalpersonas.bancochile.cl/mibancochile-web/front/persona/index.html#/mi-perfil/datos-seguridad",
+    "bandcamp.com": "https://bandcamp.com/settings",
     "bbq-grill-world.de": "https://www.bbq-grill-world.de/customer/account/edit/changepass/1/",
     "benefitslogin.discoverybenefits.com": "https://benefitslogin.discoverybenefits.com/Profile/UpdatePassword.aspx",
     "berlet.de": "https://www.berlet.de/mein-konto.htm#my-account--edit-pass",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -20,7 +20,7 @@
     "auction.co.kr": "https://memberssl.auction.co.kr/membership/MyInfo/MyInfo.aspx",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
     "bancochile.cl": "https://portalpersonas.bancochile.cl/mibancochile-web/front/persona/index.html#/mi-perfil/datos-seguridad",
-    "bandcamp.com": "https://bandcamp.com/settings",
+    "bandcamp.com": "https://bandcamp.com/settings#password",
     "bbq-grill-world.de": "https://www.bbq-grill-world.de/customer/account/edit/changepass/1/",
     "benefitslogin.discoverybenefits.com": "https://benefitslogin.discoverybenefits.com/Profile/UpdatePassword.aspx",
     "berlet.de": "https://www.berlet.de/mein-konto.htm#my-account--edit-pass",


### PR DESCRIPTION
## Description

The commits in this PR add the password change URL for bandcamp.com to the respective list. Bandcamp doesn't have a well-known password change URL, and the menu item the user needs to click is just named "Settings", so I think a direct link there from the password manager will help.

## Checklists

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

---

Hope this helps and have a nice day,
Kevin Kandlbinder (Unkn0wnCat)