### PR TITLE
Thames Water password requirements

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -549,7 +549,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%&()*+,./<=>?@_{|}~];"
     },
     "thameswater.co.uk": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%&()*+,./<=>?@_{|}~];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
     "twitter.com": {
         "password-rules": "minlength: 8;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -548,6 +548,9 @@
     "telekom-dienste.de": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%&()*+,./<=>?@_{|}~];"
     },
+    "thameswater.co.uk": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%&()*+,./<=>?@_{|}~];"
+    },
     "twitter.com": {
         "password-rules": "minlength: 8;"
     },


### PR DESCRIPTION
Thames water password requirements:
* upper
* lower
* digit
* special
* min: 8
* max:16

URL: https://www.thameswater.co.uk
Image: 
<img width="749" alt="Screenshot 2021-05-21 at 15 04 56" src="https://user-images.githubusercontent.com/1223960/119153643-549ebc00-ba49-11eb-8c69-808cf5454bdf.png">


### Overall Checklist
- [x ] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x ] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
