### PR TITLE
Add password rules for bluesguitarunleashed.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -92,6 +92,9 @@
     "bloomingdales.com": {
         "password-rules": "minlength: 7; maxlength: 16; required: lower, upper; required: digit; required: [`!@#$%^&*()+~{}'\";:<>?]];"
     },
+    "bluesguitarunleashed.com": {
+        "password-rules": "allowed: lower, upper, digit, [!$#@];"
+    },
     "box.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },


### PR DESCRIPTION
We received a report from a user that https://bluesguitarunleashed.com has password requirements specified by the given screenshot:

![image](https://user-images.githubusercontent.com/13814214/119356430-687a3600-bc74-11eb-846f-379f63677770.png)

I can't seem to find a way to reproduce this myself on the site (their signup form is behind a paywall), but it seems plausible, so adding the rule in this PR.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
