### PR TITLE
Add password rules for dickssportinggoods.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -188,6 +188,9 @@
     "devstore.cn": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },
+    "dickssportinggoods.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@^];"
+    },
     "dkb.de": {
         "password-rules": "minlength: 8; maxlength: 38; required: lower, upper; required: digit; allowed: [-äüöÄÜÖß!$%&/()=?+#,.:];"
     },


### PR DESCRIPTION
I've added the rule based off the site's requirements.

<img width="350" alt="image" src="https://user-images.githubusercontent.com/7517009/119521094-d5f79680-bd48-11eb-83de-ce5a773fd5c9.png">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)