### PR TITLE
Add password rules for sbisec.co.jp

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -494,6 +494,9 @@
     "santander.de": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit; allowed: [-!#$%&'()*,.:;=?^{}];"
     },
+    "sbisec.co.jp": {
+        "password-rules": "minlength: 10; maxlength: 20; allowed: upper,lower,digit;"
+    },
     "secure-arborfcu.org": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->
sbisec.co.jp requirements were on the [support page](https://search.sbisec.co.jp/v2/popwin/help/system_03_02.html) .

> 半角英数10～20文字をご使用ください。スペースは利用できません。

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update


#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)


