### PR TITLE
Add password rule for lsacsso.b2clogin.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -363,7 +363,7 @@
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },
     "lsacsso.b2clogin.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit, [!#$%&*-?@^_];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit, [-!#$%&*?@^_];"
     },
     "lufthansa.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -363,7 +363,7 @@
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },
     "lsacsso.b2clogin.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit,[!#$%&*+?@^];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit, [!#$%&*-?@^_];"
     },
     "lufthansa.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -362,6 +362,9 @@
     "lowes.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },
+    "lsacsso.b2clogin.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit,[!#$%&*+?@^];"
+    },
     "lufthansa.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },


### PR DESCRIPTION
A couple notes not included in the commit message:
- One option to satisfy the requirements is to encode the 3/4 requirement in six required blocks such that missing any two character classes will cause one of the requirements to fail. (e.g.: required: upper, lower; required: upper, digit; required: upper, special...). I opted against this since I'm pretty sure simplifying the requirements by always having an upper and a lower helps to preserve entropy. If you all have a different policy, let me know and I'll be happy to fix!
- Here's a screenshot of the requirement text:
<img width="420" alt="image" src="https://user-images.githubusercontent.com/3432567/120957952-854e4900-c70b-11eb-9bb7-6cd67925f922.png">

Testing:
- Tested several sets of 10000 passwords from the password generator against the website's regex.
- Checked a couple passwords against the website. It's not a website I own so I'm not going to spam them with test accounts.

commit 40c68b3010a426e06ae4639cdc35190bab1188cf
Author: mlinington <mail@mlinington.com>
Date:   Sun Jun 6 20:47:23 2021 -0700

    Add password rule for lsacsso.b2clogin.com
    
    Law school admission council password requirements:
    > 8-16 characters, containing 3 out of 4 of the following: Lowercase
    > characters, uppercase characters, digits (0-9), and one or more of the
    > following symbols: @ # $ % ^ & * - _ ! . ?
    
    The js source looks to use the following regex to perform this
    validation:
    > ( (?=.*[a-z])(?=.*[A-Z])(?=.*\d)|
    >   (?=.*[a-z])(?=.*[A-Z])(?=.*[^A-Za-z0-9])|
    >   (?=.*[a-z])(?=.*\d)(?=.*[^A-Za-z0-9])|
    >   (?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])
    > ) ([A-Za-z\d@#$%^&*\-_+=[\]{}|\\:',?/`~"();!]|\.(?!@)){8,16}
    
    There are discrepancies between the regex and the text description of
    the requirements. The regex allows more special characters but disallows
    a "@" following a "." for some reason. The rule added by this commit
    uses only the characters in the textual description, minus the "." (to
    remove the possibility of a ".@" sequence).

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
