### PR TITLE
websites-with-shared-credential-backends: Glassdoor.ca

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -276,6 +276,7 @@
         "swarmapp.com"
     ],
     [
+        "glassdoor.ca",
         "glassdoor.com",
         "glassdoor.com.ar"
     ],


### PR DESCRIPTION
Similar to https://github.com/apple/password-manager-resources/pull/79, glassdoor.ca also shares credentials with glassdoor.com

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

[WHOIS showing that glassdoor.ca](https://www.whois.com/whois/glassdoor.ca) is owned by glassdoor.com:

> Domain Name: glassdoor.ca
> Registry Domain ID: 364649-CIRA
> …
> Registry Registrant ID: 40243375-CIRA
> Registrant Name: **GLASSDOOR, INC**. TMA822107
> Registrant Organization:
> Registrant Street: 100 Shoreline Hwy Bldg A
> Registrant City: Mill Valley
> Registrant State/Province: CA
> Registrant Postal Code: 94941
> Registrant Country: US
> Registrant Phone: +1.4153399105
> Registrant Phone Ext:
> Registrant Fax: +1.4152366475
> Registrant Fax Ext:
> Registrant Email: domains@**glassdoor.com**
> Registry Admin ID: 16475178-CIRA

I can log into either domain with the same account/credentials.