### PR TITLE
Add change password URL for GOV.UK Accounts

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -3,6 +3,7 @@
     "1800contacts.com": "https://www.1800contacts.com/account/settings",
     "500px.com": "https://web.500px.com/settings/account/security",
     "aa.com": "https://www.aa.com/loyalty/profile/information",
+    "account.publishing.service.gov.uk": "https://www.account.publishing.service.gov.uk/account/edit/password",
     "acorns.com": "https://app.acorns.com/settings/change-password",
     "adobe.com": "https://account.adobe.com/security",
     "aerlingus.com": "https://www.aerlingus.com/html/user-profile.html",


### PR DESCRIPTION
This adds a change password URL for GOV.UK Accounts.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state