### PR TITLE
Add password rules for flysas.com 

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -252,7 +252,7 @@
         "password-rules": "minlength: 8; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },
     "flysas.com": {
-        "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [-(~!@#$%^&_+=`|(){}[:\"'<>,.?]];"
+        "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [-~!@#$%^&_+=`|(){}[:\"'<>,.?]];"
     },
     "fnac.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -252,7 +252,7 @@
         "password-rules": "minlength: 8; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },
     "flysas.com": {
-        "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [(-~!@#$%^&_+=`|(){}[:\"'<>,.?]];"
+        "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [-(~!@#$%^&_+=`|(){}[:\"'<>,.?]];"
     },
     "fnac.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -251,6 +251,9 @@
     "fedex.com": {
         "password-rules": "minlength: 8; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },
+    "flysas.com": {
+        "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [(-~!@#$%^&_+=`|(){}[:\"'<>,.?]];"
+    },
     "fnac.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
     },

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -264,13 +264,6 @@
         "fandango.com"
     ],
     [
-        "flysas.com",
-        "sas.dk",
-        "sas.fi",
-        "sas.no",
-        "sas.se"
-    ]
-    [
         "fnac.com",
         "fnacspectacles.com"
     ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -264,6 +264,13 @@
         "fandango.com"
     ],
     [
+        "flysas.com",
+        "sas.dk",
+        "sas.fi",
+        "sas.no",
+        "sas.se"
+    ]
+    [
         "fnac.com",
         "fnacspectacles.com"
     ],


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's [evidence](https://en.wikipedia.org/wiki/Scandinavian_Airlines) the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others.

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="759" alt="Screenshot 2021-06-09 at 02 17 51" src="https://user-images.githubusercontent.com/11087503/121274637-3b13c600-c8cb-11eb-9428-8eed0d6276a5.png">

Note that when filling a password, the green check mark for special characters will show up even if using ;*/. It however doesn't actually allow you to save the password.