### PR TITLE
websites-with-shared-credential-backends: Life Media sites

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -343,6 +343,11 @@
         "tccna.honeywell.com"
     ],
     [
+        "nintendolife.com",
+        "purexbox.com",
+        "pushsquare.com"
+    ],
+    [
         "nokia.com",
         "alcatel-lucent.com",
         "nsn-rdnet.net",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

WHOIS has only redacted info on the three domains, but on each site, they are all listing Nlife Media as the copyright owner, and on nlife.com all three are listed as separate publications run by Nlife Media, with plenty of cross-linking between sites.