### PR TITLE
websites-with-shared-credential-backends: TP-link

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -472,6 +472,10 @@
         "livenation.com"
     ],
     [
+        "tp-link.com",
+        "tplinkcloud.com"
+    ],
+    [
         "uhc.com",
         "myuhc.com"
     ],


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

WHOIS has only redacted info, but the same registrar and location. tplinkcloud.com is used for TP-Link cloud services and used from their apps, such as Tether.