### PR TITLE
Add jordancu-onlinebanking.org

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -338,6 +338,9 @@
     "japanpost.jp": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
     },
+    "jordancu-onlinebanking.org": {
+        "password-rules": "minlength: 6; maxlength: 32; allowed: upper, lower, digit,[-!\"#$%&'()*+,.:;<=>?@[^_`{|}~]];"
+    },
     "keldoc.com": {
         "password-rules": "minlength: 12; required: lower; required: upper; required: digit; required: [!@#$%^&*];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

When created a password on jordancu-onlinebanking.org, the rules say that the following special characters are valid: 

```
!@#$%^&*_+-=()[]{}|:;`,./?
```

<img width="417" alt="Screen Shot 2021-06-09 at 8 48 50 PM" src="https://user-images.githubusercontent.com/17183625/121462539-bf735100-c97e-11eb-91d0-eac4500a14fe.png">


But upon testing, I found that it allowed a few more special characters were allowed:

```
-~!@#$%^&*_+=`|(){}[:;"'<>,.?]
```


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
