### PR TITLE
Add shared backends for Braze

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -153,6 +153,10 @@
         "boudincatering.com"
     ],
     [
+        "braze.com",
+        "braze.eu"
+    ],
+    [
         "capitalone.com",
         "capitalone360.com"
     ],


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for websites-with-shared-credential-backends.json
- [x] There's evidence the domains are related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] The new group serves login pages on each of the included domains, and those login page accept accounts from the others. (For example, we don't associate `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for authentication.)

#### Evidence
https://www.braze.com/docs/api/basics/?redirected=true#endpoints

#### Explanation
Braze customer accounts belong to either the US or the EU region for GDPR purposes.  
While the actual login happens on the domain corresponding to the user's account, there's an intital step to enter a username (email) that can occur on either domain. Auto-fill of this username doesn't work smoothly because the domains aren't considered related.