### PR TITLE
Add ae.com - American Eagle Outfitters

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -11,6 +11,9 @@
     "admiral.com": {
         "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"
     },
+    "ae.com": {
+        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit;"
+    },
     "aetna.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: upper; required: digit; allowed: lower, [-_&#@];"
     },


### PR DESCRIPTION
Rules from American Eagle when changing a user password: "Passwords must be between 8-25 characters including one letter and one number and cannot match your previous three passwords."

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
