### PR TITLE
Add bcassessment.ca - BC Assessment

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -73,7 +73,7 @@
     },
     "bcassessment.ca": {
         "password-rules": "minlength: 8; maxlength: 14;"
-    }
+    },
     "benefitslogin.discoverybenefits.com": {
         "password-rules": "minlength: 10; required: upper; required: digit; required: [!#$%&*?@]; allowed: lower;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -71,6 +71,9 @@
     "battle.net": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, special;"
     },
+    "bcassessment.ca": {
+        "password-rules": "minlength: 8; maxlength: 14;"
+    }
     "benefitslogin.discoverybenefits.com": {
         "password-rules": "minlength: 10; required: upper; required: digit; required: [!#$%&*?@]; allowed: lower;"
     },


### PR DESCRIPTION
From the BC Assessment website when changing password: "Password must be at least 8-14 characters"

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
