### PR TITLE
Add a rule for Comcast Business' portal

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -89,6 +89,9 @@
     "bhphotovideo.com": {
         "password-rules": "maxlength: 15;"
     },
+    "billerweb.com": {
+        "password-rules": "minlength: 8; max-consecutive: 2; required: digit; required: upper,lower;"
+    },
     "biovea.com": {
         "password-rules": "maxlength: 19;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="840" alt="Screen Shot 2021-06-07 at 18 59 31" src="https://user-images.githubusercontent.com/234616/124971160-b7d6b480-dfdd-11eb-9088-8d2a72e12a89.png">
