### PR TITLE
Remove - special character americanexpress.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -33,7 +33,7 @@
         "password-rules": "minlength: 4; maxlength: 4;"
     },
     "americanexpress.com": {
-        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [-%&_?#=];"
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
     },
     "anatel.gov.br": {
         "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit;"


### PR DESCRIPTION
Fix https://github.com/apple/password-manager-resources/issues/486

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
