### PR TITLE
Add rule for premier.ticketek.com.au

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -479,6 +479,9 @@
     "powells.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [\"!@#$%^&*(){}[]];"
     },
+    "premier.ticketek.com.au": {
+        "password-rules": "minlength: 6; maxlength: 16;"
+    },
     "prepaid.bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
     },


### PR DESCRIPTION
Adds rule for https://premier.ticketek.com.au/Membership/JoinNow_Default.aspx which requires a password with a length of between 6 & 16 characters.

When generating a password using 1Password on the website, the saved password can be greater than 16 characters, even though the site has a `maxlength="16"` attribute on the input field.

There doesn't appear to be any other hidden password requirements around special characters, etc. A JavaScript alert is shown for the first validation rule that fails from first to last field. Trying a variety of symbol only, lowercase only, numbers only, and combinations of these types shows no error for these sample inputs.

<img width="1275" alt="image" src="https://user-images.githubusercontent.com/754567/125215790-b79d2880-e2ff-11eb-8f35-45d4e28ec24d.png">

Closes #477

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
