### PR TITLE
Remove github.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -272,9 +272,6 @@
     "girlscouts.org": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [$#!];"
     },
-    "github.com": {
-        "password-rules": "minlength: 8; required: lower, digit; allowed: unicode;"
-    },
     "gmx.net": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },


### PR DESCRIPTION
I finally got around to implementing `passwordRules` on github.com per https://github.com/apple/password-manager-resources/pull/411#issuecomment-761193713, so github.com can now be removed from this list! 😄 

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update


