### PR TITLE
Add gamestop.com password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -268,7 +268,7 @@
     },
     "gamestop.com": {
         "password-rules": "minlength: 8; maxlength: 225; required: lower; required: upper; required: digit; required: [!@#$%];"
-    }
+    },
     "getflywheel.com": {
         "password-rules": "minlength: 7; maxlength: 72;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -266,6 +266,9 @@
     "fuelrewards.com": {
         "password-rules": "minlength: 8; maxlength: 16; allowed: upper,lower,digit,[!#$%@];"
     },
+    "gamestop.com": {
+        "password-rules": "minlength: 8; maxlength: 225; required: lower; required: upper; required: digit; required: [!@#$%];"
+    }
     "getflywheel.com": {
         "password-rules": "minlength: 7; maxlength: 72;"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ ] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)

My source for the rules for these passwords:
<img width="615" alt="gamestop-html-form" src="https://user-images.githubusercontent.com/6308213/126201223-331e1d20-3950-4da7-bf85-8a4c5961743e.png">

I was able to create an account with a password length of 255 as the html attribute indicates, so I've included that in the rules for completeness:
<img width="768" alt="gamestop-html-src" src="https://user-images.githubusercontent.com/6308213/126201232-a82a23d5-47ee-46b5-bc6a-9067f814c7d9.png">

- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
