### PR TITLE
Add a quirk for questdiagnostics.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -488,6 +488,9 @@
     "qdosstatusreview.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&@^];"
     },
+    "questdiagnostics.com": {
+        "password-rules": "minlength: 8; maxlength: 30; required: upper, lower; required: digit, [!#$%&()*+<>?@^_~];"
+    },
     "rejsekort.dk": {
         "password-rules": "minlength: 7; maxlength: 15; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Here are some screenshots from the questdiagnostics.com signup page. 
<img width="634" alt="Screen Shot 2021-07-22 at 2 49 50 PM" src="https://user-images.githubusercontent.com/15079182/126713984-25cfcc5d-6a67-42b4-b6b9-c8a047384baf.png">
<img width="416" alt="Screen Shot 2021-07-22 at 2 50 49 PM" src="https://user-images.githubusercontent.com/15079182/126714025-b502a2d6-a482-4aef-88eb-5246cc91f971.png">

I tested this patch by using the "Password Rules Validation Tool" to generate some passwords. I typed them into the signup form to make sure they were accepted by the site.