### PR TITLE
Add password rules for Renaud-Bray

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -500,6 +500,9 @@
     "rejsekort.dk": {
         "password-rules": "minlength: 7; maxlength: 15; required: lower; required: upper; required: digit;"
     },
+    "renaud-bray.com": {
+        "password-rules": "minlength: 8; maxlength: 38; allowed: upper, lower, digits;"
+    },
     "ring.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!@#$%^&*<>?];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -501,7 +501,7 @@
         "password-rules": "minlength: 7; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "renaud-bray.com": {
-        "password-rules": "minlength: 8; maxlength: 38; allowed: upper, lower, digits;"
+        "password-rules": "minlength: 8; maxlength: 38; allowed: upper,lower,digit;"
     },
     "ring.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!@#$%^&*<>?];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

When testing password generation with 1Password, there are no indications of the allowed characters until after the password is rejected by the site. Only after trying a generated password does an error message appear saying that special characters and accented characters are not allowed:

<img width="463" alt="Screen Shot 2021-07-26 at 12 19 21 PM" src="https://user-images.githubusercontent.com/34867186/127024343-9feb484e-f306-47e2-a361-c05686d24890.png">
<img width="460" alt="Screen Shot 2021-07-26 at 12 19 27 PM" src="https://user-images.githubusercontent.com/34867186/127024358-e31f1841-3571-429e-b68f-bafa04667eea.png">



### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
