### PR TITLE
Resolve #281, #292, and #342

### DIFF
--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -87,6 +87,12 @@
     },
     {
         "shared": [
+            "audi.com",
+            "audiusa.com"
+        ]
+    },
+    {
+        "shared": [
             "bahn.de",
             "bahn.com"
         ]
@@ -253,6 +259,12 @@
     },
     {
         "shared": [
+            "ikonpass.com",
+            "skilynx.com"
+        ]
+    },
+    {
+        "shared": [
             "intuit.com",
             "mint.com"
         ]
@@ -336,6 +348,20 @@
     },
     {
         "shared": [
+            "myuhc.com",
+            "uhc.com",
+            "optum.com",
+            "optumrx.com"
+        ]
+    },
+    {
+        "shared": [
+            "newyorker.com",
+            "vanityfair.com"
+        ]
+    },
+    {
+        "shared": [
             "nintendolife.com",
             "purexbox.com",
             "pushsquare.com"
@@ -353,12 +379,6 @@
         "shared": [
             "norwegianreward.com",
             "norwegian.com"
-        ]
-    },
-    {
-        "shared": [
-            "optumrx.com",
-            "optum.com"
         ]
     },
     {
@@ -495,12 +515,6 @@
         "shared": [
             "tp-link.com",
             "tplinkcloud.com"
-        ]
-    },
-    {
-        "shared": [
-            "uhc.com",
-            "myuhc.com"
         ]
     },
     {

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -57,6 +57,13 @@
         ]
     },
     {
+        "shared": [
+            "airnewzealand.co.nz",
+            "airnewzealand.com",
+            "airnewzealand.com.au"
+        ]
+    },
+    {
         "from": [
             "discordapp.com"
         ],
@@ -115,6 +122,15 @@
             "eventbrite.pt",
             "eventbrite.se",
             "eventbrite.sg"
+        ]
+    },
+    {
+        "from": [
+            "nordvpn.com",
+            "nordpass.com"
+        ],
+        "to": [
+            "nordaccount.com"
         ]
     },
     {

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -69,6 +69,11 @@
         "flyingblue.com"
     ],
     [
+        "airnewzealand.co.nz",
+        "airnewzealand.com",
+        "airnewzealand.com.au"
+    ],
+    [
         "alltrails.com",
         "alltrails.io"
     ],
@@ -117,6 +122,10 @@
     [
         "att.com",
         "att.net"
+    ],
+    [
+        "audi.com",
+        "audiusa.com"
     ],
     [
         "bahn.de",
@@ -289,6 +298,10 @@
         "gogoinflight.com"
     ],
     [
+        "ikonpass.com",
+        "skilynx.com"
+    ],
+    [
         "intuit.com",
         "mint.com"
     ],
@@ -348,6 +361,16 @@
         "tccna.honeywell.com"
     ],
     [
+        "myuhc.com",
+        "uhc.com",
+        "optum.com",
+        "optumrx.com"
+    ],
+    [
+        "newyorker.com",
+        "vanityfair.com"
+    ],
+    [
         "nintendolife.com",
         "purexbox.com",
         "pushsquare.com"
@@ -359,12 +382,13 @@
         "nsn.com"
     ],
     [
-        "norwegianreward.com",
-        "norwegian.com"
+        "nordvpn.com",
+        "nordpass.com",
+        "nordaccount.com"
     ],
     [
-        "optumrx.com",
-        "optum.com"
+        "norwegianreward.com",
+        "norwegian.com"
     ],
     [
         "pinterest.com",
@@ -484,10 +508,6 @@
     [
         "tp-link.com",
         "tplinkcloud.com"
-    ],
-    [
-        "uhc.com",
-        "myuhc.com"
     ],
     [
         "umsystem.edu",


### PR DESCRIPTION
I also include ikonpass.com/skilynx.com from my own experience.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [x] You believe that the domains were associated at some point in the past and can explain that relationship