### PR TITLE
Password rules and change password url for carsandbids.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -31,6 +31,7 @@
     "blutdruck-shop.de": "https://www.blutdruck-shop.de/mein-passwort/",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
     "callofduty.com": "https://profile.callofduty.com/cod/info",
+    "carsandbids.com": "https://carsandbids.com/account/settings",
     "carta.com": "https://app.carta.com/profiles/update/",
     "cecredentialtrust.com": "https://secure.cecredentialtrust.com/account/editpassword/",
     "censys.io": "https://censys.io/account",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -119,6 +119,9 @@
     "cardbenefitservices.com": {
         "password-rules": "minlength: 7; maxlength: 100; required: lower, upper; required: digit;"
     },
+    "carsandbids.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()*+./:=?@[\^_`{}]];"
+    }
     "cb2.com": {
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Screenshot:
![Screen Shot 2021-08-04 at 13 17 24](https://user-images.githubusercontent.com/2300603/128225445-131702f1-37e1-4053-b958-201634fda6cc.png)

Also, I am a developer at CarsAndBids.com, and I can confirm these requirements are correct.


#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state