### PR TITLE
Add kfc.ca

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -359,6 +359,9 @@
     "key.harvard.edu": {
         "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^[']];"
     },
+    "kfc.ca": {
+        "password-rules": "required: lower; required: upper; required: digit; required: [!@#$%&?*];"
+    },
     "klm.com": {
         "password-rules": "minlength: 8; maxlength: 12;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -360,7 +360,7 @@
         "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^[']];"
     },
     "kfc.ca": {
-        "password-rules": "required: lower; required: upper; required: digit; required: [!@#$%&?*];"
+        "password-rules": "minlength: 6; maxlength: 15; required: lower; required: upper; required: digit; required: [!@#$%&?*];"
     },
     "klm.com": {
         "password-rules": "minlength: 8; maxlength: 12;"


### PR DESCRIPTION
Add kfc.ca credential quirks. Per the website password change form: 
```Passwords must include an uppercase letter, a lowercase letter, a number, and one of the following symbols: !@#$%&?*```

Had to test for minimum and maximum, and the values I've specified in this PR seem to be correct in my testing.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
