### PR TITLE
Added rule for visabenefits-auth.axa-assistance.us

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -631,7 +631,7 @@
     },
     "visabenefits-auth.axa-assistance.us": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&()*,.:<>?@^{|}];"
-    }
+    },
     "vivo.com.br": {
         "password-rules": "maxlength: 6; max-consecutive: 3; allowed: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -629,6 +629,9 @@
     "visa.com": {
         "password-rules": "minlength: 6; maxlength: 32;"
     },
+    "visabenefits-auth.axa-assistance.us": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&()*,.:<>?@^{|}];"
+    }
     "vivo.com.br": {
         "password-rules": "maxlength: 6; max-consecutive: 3; allowed: digit;"
     },


### PR DESCRIPTION
The [signup page ](https://visabenefits-auth.axa-assistance.us/login) lists the following password requirements 

> * Be at least 8 characters
> * At least one number
> * At least one special character
> * At least one capital letter
> * At least one lowercase letter
> * The password should not contain the first name or last name or e-mail

I got the list of the special characters looking in the page source code. There doesn't seems to be a maximum length

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
