### PR TITLE
Add some shared credentials entries to resolve issues for @MattSLangford

### DIFF
--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -440,7 +440,8 @@
         "shared": [
             "shopdisney.com",
             "go.com",
-            "disneyplus.com"
+            "disneyplus.com",
+            "espn.com"
         ]
     },
     {
@@ -535,6 +536,7 @@
     },
     {
         "shared": [
+            "verizon.com",
             "verizonwireless.com",
             "vzw.com"
         ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -457,7 +457,8 @@
     [
         "shopdisney.com",
         "go.com",
-        "disneyplus.com"
+        "disneyplus.com",
+        "espn.com"
     ],
     [
         "slcl.overdrive.com",
@@ -522,6 +523,7 @@
         "unitedwifi.com"
     ],
     [
+        "verizon.com",
         "verizonwireless.com",
         "vzw.com"
     ],


### PR DESCRIPTION
https://twitter.com/mattslangford/status/1425540658438316033?s=21

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials-historical.json
- [x] You believe that the domains were associated at some point in the past and can explain that relationship