### PR TITLE
Add rules for major HK banks

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -105,7 +105,7 @@
         "password-rules": "allowed: lower, upper, digit, [!$#@];"
     },
     "bochk.com": {
-        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [#$%&()*+,.:;<=>?@_];"
+        "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [#$%&()*+,.:;<=>?@_];"
     },
     "box.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -293,6 +293,9 @@
     "gwl.greatwestlife.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [-!#$%_=+<>];"
     },
+    "hangseng.com": {
+        "password-rules": "minlength: 8; maxlength: 30; required: lower; required: upper; required: digit;"
+    },
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -104,6 +104,9 @@
     "bluesguitarunleashed.com": {
         "password-rules": "allowed: lower, upper, digit, [!$#@];"
     },
+    "bochk.com": {
+        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [#$%&()*+,.:;<=>?@_];"
+    },
     "box.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -188,6 +188,9 @@
     "darty.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
     },
+    "dbs.com.hk": {
+        "password-rules": "minlength: 8; maxlength: 30; required: lower; required: upper; required: digit;"
+    },
     "decluttr.com": {
         "password-rules": "minlength: 8; maxlength: 45; required: lower; required: upper; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -308,6 +308,9 @@
     "hilton.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"
     },
+    "hkbea.com": {
+        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
+    },    
     "hotels.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: digit; allowed: lower, upper, [@$!#()&^*%];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -311,6 +311,9 @@
     "hrblock.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [$#%!];"
     },
+    "hsbc.com.hk": {
+        "password-rules": "minlength: 6; maxlength: 30; required: lower; required: upper; required: digit; allowed: ['.@_];"
+    },
     "hsbc.com.my": {
         "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!$*.=?@_'];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship


### Rules

#### [hsbc.com.hk](https://www.ebanking.hsbc.com.hk/1/2/faq/popsecadpwd)

> The secret word or code you will use to access your Internet banking service. You will specify you own password. Your password should be created in 6-30 characters. You may use a combination of numbers (0-9), and/or upper and lower case letters (A-Z, a-z), and/or special characters such as (@), underscore (_), hyphen (-), apostrophe (') and period (.). Other special characters will not be accepted.

#### [bochk.com](https://its.bochk.com/setting/help/ibs_set_help_e.html#chgPwd)
> 1. Your password must be in 8-12 digits and comprises at least any 2 types of the combination of uppercase letters, lowercase letters, numbers and symbols, and should not contain 3 or more consecutive identical characters. Uppercase letters and lowercase letters are considered different characters.
> 2. The new password may include i) numbers, ii) uppercase letters, iii) lowercase letters, iv) symbols: # $ % & ( ) * + , - . : ; ? @ = _ < >

#### [hangseng.com](https://www.hangseng.com/cms/emkt/pmo/grp06/p06/eng/faq.html)
> Your First Password and Second Password should be created in 8-30 characters. You may use a combination of numbers (0-9), and/or upper and lower case letters (A-Z, a-z). To better safeguard your Personal e-Banking account, we suggest you create new passwords which are different from your existing password and Date-of-Birth.

#### [hkbea.com](https://www.hkbea.com/html/en/bea-app-faqs.html)
> Your Cyberbanking password must be 8 to 12 characters, and contain letter(s) (A-Z) and at least 2 numbers (0-9);

#### [dbs.com.hk](https://www.dbs.com.hk/ibanking/help-preference.html)
> New password must be made up of 8 to 30 characters with the combination of uppercase letters, lowercase letters and numbers.