### PR TITLE
Add Envato domains with shared credential backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The _Password Manager Resources_ project exists so creators of password managers
 "Quirk" is a term from web browser development that refers to a website-specific, hard-coded behavior to work around an issue with a website that can't be fixed in a principled, universal way. In this project, it has the same meaning. Although ideally, the industry will work to eliminate the need for all of the quirks in this project, there's value in customizing behaviors to ensure better user experience. The current quirks are:
 
 * [**Password Rules**](#password-rules): Rules to generate compatible passwords with websites' particular requirements.
-* [**Websites with Shared Credential Backends**](#websites-with-shared-credential-backends): Groups of websites known to use the same credential backend, which can be used to enhance suggested credentials to sign in to websites.
+* [**Shared Credentials**](#shared-credentials): Groups of websites known to use the same credential backend, which can be used to enhance suggested credentials to sign in to websites.
 * [**Change Password URLs**](#change-password-urls): To drive the adoption of strong passwords, it's useful to be able to take users directly to websites' change password pages.
 * [**Websites Where 2FA Code is Appended to Password**](#websites-where-2fa-code-is-appended-to-password): Some websites use a two-factor authentication scheme where the user must append a generated code to their password when signing in.
 

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -1,6 +1,20 @@
 [
     {
         "shared": [
+            "3docean.net",
+            "audiojungle.net",
+            "codecanyon.net",
+            "envato.com",
+            "graphicriver.net",
+            "photodune.net",
+            "placeit.net",
+            "themeforest.net",
+            "tutsplus.com",
+            "videohive.net"
+        ]
+    },
+    {
+        "shared": [
             "airbnb.com.ar",
             "airbnb.com.au",
             "airbnb.at",

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -1,5 +1,17 @@
 [
     [
+        "3docean.net",
+        "audiojungle.net",
+        "codecanyon.net",
+        "envato.com",
+        "graphicriver.net",
+        "photodune.net",
+        "placeit.net",
+        "themeforest.net",
+        "tutsplus.com",
+        "videohive.net"
+    ],
+    [
         "aa.com",
         "americanairlines.com",
         "americanairlines.jp"


### PR DESCRIPTION
I grabbed the list from https://envato.com/sitemap/, which has links to all of these domains. On all the sites, they all feature Envato's branding in the header and on the login page. All the domains have links to the others.

I also fixed a broken anchor in the README:
> In #497, the "Websites with Shared Credential Backends" section in the README was renamed to "Shared Credentials". This broke the link anchor shown under the "Welcome!" section.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
