### PR TITLE
Add shared credentials for US Sailing and US Powerboating

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -160,8 +160,8 @@
     },
     {
         "shared": [
-            "ussailing.org",
-            "uspowerboating.com"
+            "uspowerboating.com",
+            "ussailing.org"
         ]
     },
     {

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -160,6 +160,12 @@
     },
     {
         "shared": [
+            "ussailing.org",
+            "uspowerboating.com"
+        ]
+    },
+    {
+        "shared": [
             "wikipedia.org",
             "mediawiki.org",
             "wikibooks.org",

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -523,6 +523,10 @@
         "unitedwifi.com"
     ],
     [
+        "ussailing.org",
+        "uspowerboating.com"
+    ]
+    [
         "verizon.com",
         "verizonwireless.com",
         "vzw.com"

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -523,9 +523,9 @@
         "unitedwifi.com"
     ],
     [
-        "ussailing.org",
-        "uspowerboating.com"
-    ]
+        "uspowerboating.com",
+        "ussailing.org"
+    ],
     [
         "verizon.com",
         "verizonwireless.com",


### PR DESCRIPTION
Added shared credentials between ussailing.org and uspowerboating.com. Each site has its own login page but credentials are shared between the two sites. This can be seen best on [uspowerboating.com's login page](https://www1.uspowerboating.com/user/Login.aspx?cmsReturn=autoclose.aspx) where clicking the "Forgot member ID" or "Forgot password" links will take you back to ussailing.org.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.