### PR TITLE
Added password rule for lloydsbank.co.uk

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -393,7 +393,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
     "lloydsbank.co.uk" : {
-        "passwordrules" : "minlength: 8; maxlength: 15; required: lower; required: digit; allowed: upper"
+        "passwordrules" : "minlength: 8; maxlength: 15; required: lower; required: digit; allowed: upper;"
     },
     "lowes.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -392,6 +392,9 @@
     "live.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
+    "lloydsbank.co.uk" : {
+        "passwordrules" : "minlength: 8; maxlength: 15; required: lower; required: digit; allowed: upper"
+    },
     "lowes.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },


### PR DESCRIPTION
Lloyds Bank have the following rules when creating a online banking password for UK personal banking customers:
- "Use between 8 and 15 characters, without spaces or special characters".
- "Include letters and numbers (at least 3 letters and 1 number)."
- "Exclude personal details like your name, birthday or email address."
- "Exclude previous passwords or your logon details."
- "Avoid common passwords like 'password' or '12345'"  

<img width="200" alt="Screenshot 2021-09-12 at 19 18 52" src="https://user-images.githubusercontent.com/75224610/132998821-b29bf6b3-a200-4327-89b4-e19265011a4c.png">

Added under lloydsbank.co.uk and lloydsbank.com redirects to .co.uk for both account creation and sign in.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
