### PR TITLE
shared-credentials: Add vistaprint.ca => account.vistaprint.com

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -179,6 +179,15 @@
         ]
     },
     {
+        "from": [
+            "www.vistaprint.ca"
+        ],
+        "to": [
+            "account.vistaprint.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "wikipedia.org",
             "mediawiki.org",


### PR DESCRIPTION
A new vistaprint.ca was launched which now handles authentication via account.vistaprint.com. Other regional sites I checked were (including vistaprint.com) were still serving login on their own domain at `/vp/ns/sign_in.aspx`.

https://www.vistaprint.ca/hub/change-is-here-and-its-good/

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
-- If you click login at www.vistaprint.ca you will see it take you to account.vistaprint.com
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
