### PR TITLE
Add password rules for prestocard.ca

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -515,6 +515,9 @@
     "prepaid.bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
     },
+	"prestocard.ca": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit,[!\"#$%&'()*+,<>?@];"
+    },
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -515,7 +515,7 @@
     "prepaid.bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
     },
-	"prestocard.ca": {
+    "prestocard.ca": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit,[!\"#$%&'()*+,<>?@];"
     },
     "propelfuels.com": {


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

Rules are based off the requirements error I got when I used Safari's generated strong password.

<img width="1040" alt="Screen Shot 2021-09-24 at 10 02 39 PM" src="https://user-images.githubusercontent.com/7517009/134754523-404b41db-8e6c-4407-937e-89a70a46c45d.png">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)