### PR TITLE
Add protonmail.com/protonmail.ch from shared credentials to proton.me

### DIFF
--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -442,12 +442,6 @@
     },
     {
         "shared": [
-            "protonmail.com",
-            "protonvpn.com"
-        ]
-    },
-    {
-        "shared": [
             "qnap.com",
             "myqnapcloud.com"
         ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -440,6 +440,14 @@
     },
     {
         "shared": [
+            "proton.me",
+            "protonvpn.com",
+            "protonmail.ch",
+            "protonmail.com"
+        ]
+    },
+    {
+        "shared": [
             "quicken.com",
             "simplifimoney.com"
         ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -634,8 +634,10 @@
         "probikeshop.com"
     ],
     [
-        "protonmail.com",
-        "protonvpn.com"
+        "proton.me",
+        "protonvpn.com",
+        "protonmail.ch",
+        "protonmail.com"
     ],
     [
         "qnap.com",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [X] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [X] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)

---
~~There is a support article on protonmail.com that explains the existence of the protonmail.ch domain for webmail logins: https://protonmail.com/support/knowledge-base/what-is-the-difference-between-protonmail-com-and-protonmail-ch/~~

It seems that ProtonMail is migrating from protonmail.ch/protonmail.com to proton.me. app.protonmail.ch is redirected for me (status code 301). mail.protonmail.com seems to be still available, but a banner is shown at the top of the website. I have added both as `from` domains and marked the `fromDomainsAreObsoleted` key as `false`. protonvpn.com is still available. 

See also #378 for the reasons for adding protonvpn.com domain (the accounts are still connected).