### PR TITLE
Add-password-rules-runescape

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -545,6 +545,9 @@
     "rogers.com": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; required: [!@#$];"
     },
+    "runescape.com": {
+        "password-rules": "minlength: 5; maxlength: 20; required: lower; required: upper; required: digit;"
+    },
     "ruten.com.tw": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower, upper;"
     },


### PR DESCRIPTION
Password rules for RuneScape (first time using GitHub or doing a "pull request". Happy to fix any errors)

Minimum 5 characters, Maximum 20 characters, digit required, no special characters allowed

"runescape.com": {
"password-rules": "minlength: 5; maxlength: 20; required: lower; required: upper; required: digit;"

![134284639-24b45105-eae0-486d-8fda-c9c07a46c8d0](https://user-images.githubusercontent.com/54270277/134973429-b67add23-ac1c-4fca-976d-19a4e6ee9041.PNG)


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
