### PR TITLE
Add password-rules for snnow.ca

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -567,7 +567,7 @@
         "password-rules": "minlength: 6; maxlength: 15; required: lower; required: digit; allowed: ascii-printable;"
     },
     "secure.snnow.ca": {
-        "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper, digit;"
+        "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper;"
     },
     "secure.wa.aaa.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: ascii-printable;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -566,6 +566,9 @@
     "secure.orclinic.com": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower; required: digit; allowed: ascii-printable;"
     },
+    "secure.snnow.ca": {
+        "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper, digit;"
+    },
     "secure.wa.aaa.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },
@@ -583,9 +586,6 @@
     },
     "signin.ea.com": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
-    },
-    "secure.snnow.ca": {
-        "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper, digit;"
     },
     "southwest.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: upper; required: digit; allowed: lower, [!@#$%^*(),.;:/\\];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -584,6 +584,9 @@
     "signin.ea.com": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
+    "secure.snnow.ca": {
+        "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper, digit;"
+    },
     "southwest.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: upper; required: digit; allowed: lower, [!@#$%^*(),.;:/\\];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

![20210929_140717@2x](https://user-images.githubusercontent.com/104145/135324718-4bf62ddc-7ec2-4ba1-80d5-79c969820741.png)
