### PR TITLE
Adding password rule for wegmans.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -689,6 +689,9 @@
     "web.de": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },
+    "wegmans.com": {
+        "password-rules": "minlength: 8; required: digit; required: upper,lower; required: [!#$%&*+=?@^];"
+    },
     "weibo.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Rules from Change Password form:
> Minimum of 8 characters long. Must include one letter and one number. May include ! @ $ % ^ & + = ? *

Apple's password manager defaults to using `-` character, which is "Unacceptable" at wegmans.com
![Using a password with a `-` is "Unacceptable" at wegmans.com.](https://user-images.githubusercontent.com/1134568/137396793-431a09dd-cd8c-4f39-a3a4-7790d63c9537.png)

While the rules note that a password _may_ include ` ! @ $ % ^ & + = ? *`, it is less favorable if they are not included.
![Using a password with only letters and numbers results in a less favorable password.](https://user-images.githubusercontent.com/1134568/137397220-895cb34c-0a87-478b-b199-392d582f7dab.png)

Setting the rule to require (instead of only allow) ` ! @ $ % ^ & + = ? *` generates more favorable passwords.
![Using a password with special characters results in a more favorable password.](https://user-images.githubusercontent.com/1134568/137397423-de87ba0f-0a44-4400-88a3-64f7784bf25e.png)


