### PR TITLE
Add Albertsons-affiliated stores that use the same backend (albertson…

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -15,6 +15,21 @@
     },
     {
         "shared": [
+            "albertsons.com",
+            "acmemarkets.com",
+            "carrsqc.com",
+            "jewelosco.com",
+            "pavilions.com",
+            "randalls.com",
+            "safeway.com",
+            "shaws.com",
+            "starmarket.com",
+            "tomthumb.com",
+            "vons.com"
+        ]
+    },
+    {
+        "shared": [
             "airbnb.com.ar",
             "airbnb.com.au",
             "airbnb.at",
@@ -85,7 +100,7 @@
             "blade.com"
         ],
         "fromDomainsAreObsoleted": true
-    }
+    },
     {
         "from": [
             "discordapp.com"

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -86,6 +86,19 @@
         "airnewzealand.com.au"
     ],
     [
+        "albertsons.com",
+        "acmemarkets.com",
+        "carrsqc.com",
+        "jewelosco.com",
+        "pavilions.com",
+        "randalls.com",
+        "safeway.com",
+        "shaws.com",
+        "starmarket.com",
+        "tomthumb.com",
+        "vons.com"
+    ],
+    [
         "alltrails.com",
         "alltrails.io"
     ],
@@ -287,6 +300,10 @@
     [
         "fandangonow.com",
         "fandango.com"
+    ],
+    [
+        "flyblade.com",
+        "blade.com"
     ],
     [
         "fnac.com",
@@ -598,5 +615,9 @@
     [
         "wsj.com",
         "dowjones.com"
+    ],
+    [
+        "www.vistaprint.ca",
+        "account.vistaprint.com"
     ]
 ]


### PR DESCRIPTION
…s.okta.com) to shared credentials

I went through the sites listed at https://www.albertsonscompanies.com and tested which ones used the same
CMS and submitted to the same identity provider.

While here, I fixed a syntax error and ran the converter script.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
