### PR TITLE
Add a rule for salslimo.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -569,6 +569,9 @@
     "ruten.com.tw": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower, upper;"
     },
+    "salslimo.com": {
+        "password-rules": "minlength: 8; maxlength: 50; required: upper; required: lower; required: digit; required: [!@#$&*];"
+    },
     "santahelenasaude.com.br": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [-!@#$%&*_+=<>];"
     },


### PR DESCRIPTION
Reverse engineered from website testing and this markup:

```
<input autocomplete="current-password" class="form-control" data-val="true" data-val-regex="Password is not complex enough" data-val-regex-pattern="^(?=.*[A-Z])(?=.*[!@#$&amp;*])(?=.*[0-9])(?=.*[a-z]).{8,50}$" data-val-required="The Password field is required." id="passwordReg" name="Password" onkeyup="Ores4Accounts.validatePassword();" tabindex="10" type="password">
```

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)