### PR TITLE
Add password rule for usps.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -623,6 +623,9 @@
     "user.ornl.gov": {
         "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!#$%./_];"
     },
+    "usps.com": {
+        "password-rules": "minlength: 8; maxlength: 50; max-consecutive: 2; required: lower; required: upper; required: digit; allowed: [-!\"#&'()+,./?@];"
+    },
     "vanguard.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

![image](https://user-images.githubusercontent.com/29067983/139066997-d86f2d5e-4016-42aa-8391-93b67295324b.png)

I checked the passwords generated with this rule both on https://developer.apple.com/password-rules/ and with 1Password, and the generated passwords work great.