### PR TITLE
Fix syntax errors for fidelity.com and hkexpress.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -279,7 +279,7 @@
         "password-rules": "minlength: 8; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },
     "fidelity.com": {
-        "password-rules": "minlength: 6; maxlength: 20; required: lower; allowed: upper,digit,[!$%'()+,./:;=?@\^_|~];"
+        "password-rules": "minlength: 6; maxlength: 20; required: lower; allowed: upper,digit,[!$%'()+,./:;=?@^_|~];"
     },
     "flysas.com": {
         "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [-~!@#$%^&_+=`|(){}[:\"'<>,.?]];"
@@ -330,7 +330,7 @@
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
     },
     "hkexpress.com" : {
-        "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: special;"
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: special;"
     },
     "hotels.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: digit; allowed: lower, upper, [@$!#()&^*%];"


### PR DESCRIPTION
The fidelity.com entry contains an invalid escape sequence and the hkexpress.com one is missing the dict key.
Parsing this file with most JSON parsers should fail right now.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

