### PR TITLE
Launtel.net.au requires two digits

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -404,6 +404,9 @@
     "ladwp.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: digit; allowed: lower, upper;"
     },
+    "launtel.net.au": {
+        "password-rules": "minlength: 8; required: digit; required: digit; allowed: upper,lower;"
+    }
     "leetchi.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -405,7 +405,7 @@
         "password-rules": "minlength: 8; maxlength: 20; required: digit; allowed: lower, upper;"
     },
     "launtel.net.au": {
-        "password-rules": "minlength: 8; required: digit; required: digit; allowed: upper,lower;"
+        "password-rules": "minlength: 8; required: digit; required: digit; allowed: lower, upper;"
     }
     "leetchi.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"


### PR DESCRIPTION
Turns out they require two digits, and the generator seemed to work with this.
![IMG_2356](https://user-images.githubusercontent.com/3939499/144351681-e7e50fe5-90e2-46e9-b2bd-0a99bf99e549.jpg)


---
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)