### PR TITLE
Fix invalid JSON in the password-rules.json file

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -406,7 +406,7 @@
     },
     "launtel.net.au": {
         "password-rules": "minlength: 8; required: digit; required: digit; allowed: lower, upper;"
-    }
+    },
     "leetchi.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
@@ -414,7 +414,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
     "lloydsbank.co.uk" : {
-        "passwordrules" : "minlength: 8; maxlength: 15; required: lower; required: digit; allowed: upper;"
+        "password-rules" : "minlength: 8; maxlength: 15; required: lower; required: digit; allowed: upper;"
     },
     "lowes.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"


### PR DESCRIPTION
Some invalid JSON slipped in to the `password-rules.json` file. This PR corrects that.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update