### PR TITLE
Add-password-rules-mpv.tickets.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -458,6 +458,9 @@
     "mlb.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!\"#$%&'()*+,./:;<=>?[\\^_`{|}~]];"
     },
+    "mpv.tickets.com": {
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
+    },
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Found out the ticketing site to book for my grad doesn't allow for the easy creation of passwords :(

Picture attached with password rules.
![UH Clear Lake Commencement - MyProVenue™](https://user-images.githubusercontent.com/54270277/145326062-887d2208-754a-4724-abdd-494e4578f924.jpeg)

