### PR TITLE
Add Discord Merch shared credential

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -112,6 +112,12 @@
     },
     {
         "shared": [
+            "discordmerch.com",
+            "discord.store"
+        ]
+    },
+    {
+        "shared": [
             "ebay.at",
             "ebay.be",
             "ebay.ca",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)

Evidence:
<details>
<summary>https://discord.com/snowsgiving</summary>
<br>
<img src="https://user-images.githubusercontent.com/53608074/146049060-a9adc9f6-3860-4410-ad63-27760afb94f6.png">
<img src="https://user-images.githubusercontent.com/53608074/146049175-475c9097-4b44-409f-b342-9337e14f663b.png">
</details>

<details>
<summary>Discord Snowsgiving/Town Hall server</summary>
<br>
<img src="https://user-images.githubusercontent.com/53608074/146049522-37b44879-df78-4e72-9eab-06ff6d4ca967.png">
</details>

<details>
<summary>Other</summary>
<br>
<a href="https://support.discord.com/hc/en-us/articles/360059570333-Discord-Merchandise-Store-FAQ" target="_blank">Discord Merchandise FAQ</a>
</details>