### PR TITLE
Add password rules for lg.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -413,6 +413,9 @@
     "leetchi.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
+    "lg.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit;"
+    },
     "live.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -417,7 +417,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
     "lg.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
     },
     "live.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -50,6 +50,9 @@
     "app.digio.in": {
         "password-rules": "minlength: 8; maxlength: 15;"
     },
+    "app.parkmobile.io": {
+        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!@#$%^&];"
+    },
     "apple.com": {
         "password-rules": "minlength: 8; maxlength: 63; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },
@@ -502,9 +505,6 @@
     },
     "packageconciergeadmin.com": {
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
-    },
-    "app.parkmobile.io": {
-        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!@#$%^&];"
     },
     "paypal.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower, upper; required: digit, [!@#$%^&*()];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -417,7 +417,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
     "lg.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-!#$%&'()*+,.:;=?@[^_{|}~]];"
     },
     "live.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"


### PR DESCRIPTION
This PR adds password rules for lg.com. 

<img width="456" alt="Screen Shot 2021-12-22 at 4 13 37 PM" src="https://user-images.githubusercontent.com/17183625/147169742-fbf1d954-6a0e-4a82-b7e1-1789b6a569e2.png">

<img width="666" alt="Screen Shot 2021-12-22 at 4 22 23 PM" src="https://user-images.githubusercontent.com/17183625/147169750-511029fc-375d-422d-a595-0b1e48566611.png">

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
