### PR TITLE
add password rules for preferredhotels.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -536,6 +536,9 @@
     "powells.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [\"!@#$%^&*(){}[]];"
     },
+    "preferredhotels.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+@^_];"
+    },
     "premier.ticketek.com.au": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },


### PR DESCRIPTION
This is the rewards program from a hotel chain. The password rules stated on the website are:

- Password must be at least 8 characters long.
- Password must contain at least one upper case and one lower case letter.
- Password must contain at least one number.
- Password must contain one of the following !#$%&()*+@^_

I've tried a few generated passwords generated by these rules and they all seem to work. Here is a screenshot showing the requirements from the website:


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

![Screenshot 2022-01-14 at 09 15 24](https://user-images.githubusercontent.com/7751234/149490823-99370524-ffd5-41dd-ae2a-357bd43233fb.png)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
