### PR TITLE
Add change password URL for shutterfly

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -114,6 +114,7 @@
     "shodan.io": "https://account.shodan.io/change_password",
     "shoop.de": "https://www.shoop.de/einstellungen/benutzerdaten",
     "shopback.co.kr": "https://www.shopback.co.kr/account/change-password",
+    "shutterfly.com": "https://www.shutterfly.com/account-settings/",
     "sipgatebasic.de": "https://app.sipgatebasic.de/settings",
     "sonos.com": "https://www.sonos.com/myaccount/user/profile/",
     "speedway.com": "https://www.speedway.com/my-account/security/passcode",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
