### PR TITLE
Add shared credentials for TVNOW, auth.rtl.de and rtlplus

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -204,6 +204,16 @@
     },
     {
         "shared": [
+            "auth.rtl.de",
+            "rtlplus.de",
+            "rtlplus.com",
+            "tvnow.de",
+            "tvnow.at",
+            "tvnow.ch"
+        ]
+    },
+    {
+        "shared": [
             "uspowerboating.com",
             "ussailing.org"
         ]


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
*  rtlplus.de, rtlplus.com, tvnow.at, tvnow.ch redirect to tvnow.de
* the impressum of rtl.de (https://www.rtl.de/cms/service/footer-navigation/impressum.html) and tvnow.de (https://www.tvnow.de/impressum) shows that both domains are part of RTL interactive GmbH
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
