### PR TITLE
Add my.konami.net

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -473,6 +473,9 @@
     "myhealthrecord.com": {
         "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
     },
+    "my.konami.net": {
+        "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"
+    },
     "mysubaru.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

I did some testing and the website does not seem to care if your password is all lower-case or all upper-case. The only hard requirement is that it must be within 8-32 characters and contain a digit, no symbols allowed.

Knowing this, should it be changed to "allowed: lower; allowed: upper; required: digit;" ?  I'm not sure, happy to change if need be! Thanks!

What I suggested of required: lower, upper, digit works perfectly fine though.

<img width="953" alt="Screen Shot 2022-01-27 at 2 04 18 PM" src="https://user-images.githubusercontent.com/54270277/151437155-dd10e4d1-4aa1-4035-a5c4-a26a3c9b7f76.png">

