### PR TITLE
Add seek domains to shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -285,6 +285,16 @@
     },
     {
         "from": [
+            "www.seek.com.au",
+            "www.seek.co.nz"
+        ],
+        "to": [
+            "login.seek.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "www.vistaprint.ca"
         ],
         "to": [


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

Evidence:
If you go to https://www.seek.com.au and click 'Sign In' or 'Register' you will be taken to https://login.seek.com
If you go to https://www.seek.co.nz and click 'Sign In' or 'Register' you will be taken to https://login.seek.com
You can also register on AU and then sign in on NZ, they share the same credential backend.
