### PR TITLE
Password quirks for Technical Univeristy of Munich (TUM)

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -134,6 +134,7 @@
     "todoist.com": "https://todoist.com/prefs/account",
     "trakt.tv": "https://trakt.tv/settings#password",
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
+    "tum.de": "https://campus.tum.de",
     "twilio.com": "https://www.twilio.com/console/user/settings",
     "twitch.tv": "https://www.twitch.tv/settings/security",
     "udacity.com": "https://classroom.udacity.com/settings/password",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -50,6 +50,9 @@
     "app.digio.in": {
         "password-rules": "minlength: 8; maxlength: 15;"
     },
+    "app.parkmobile.io": {
+        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!@#$%^&];"
+    },
     "apple.com": {
         "password-rules": "minlength: 8; maxlength: 63; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },
@@ -467,6 +470,9 @@
     "mpv.tickets.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
+    "my.konami.net": {
+        "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"
+    },
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
@@ -475,9 +481,6 @@
     },
     "myhealthrecord.com": {
         "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
-    },
-    "my.konami.net": {
-        "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"
     },
     "mysubaru.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"
@@ -505,9 +508,6 @@
     },
     "packageconciergeadmin.com": {
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
-    },
-    "app.parkmobile.io": {
-        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!@#$%^&];"
     },
     "paypal.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower, upper; required: digit, [!@#$%^&*()];"

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -175,6 +175,14 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "shared": [
+            "lrz.de",
+            "mwn.de",
+            "mytum.de",
+            "tum.de"
+        ]
+    },
+    {
         "from": [
             "nordvpn.com",
             "nordpass.com"


### PR DESCRIPTION
### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### ~for password-rules.json~
- [ ] ~The given rule isn't particularly standard and obvious for password managers~
- [ ] ~Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)~
- [ ] ~Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)~
- [ ] ~The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)~

#### for change-password-URLs.json
- [X] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [X] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [X] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [X] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] ~If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.~

#### ~for shared-credentials-historical.json~
- [ ] ~You believe that the domains were associated at some point in the past and can explain that relationship~

---

Here are some login pages:
- https://portal.mytum.de/login_form
- https://login.tum.de servers a Shibboleth (SAML) Login Service
- http://gitlab.lrz.de and https://idmportal.lrz.de
- https://xmail.mwn.de hosts webmail (see [documentation](https://doku.lrz.de/pages/viewpage.action?pageId=19103885) about relationship to TUM)

And here is some evidence regarding the relationship between tum.de, mytum.de, lrz.de, and mwn.de:
- LRZ (`lrz.de`) is the "Leibniz Supercomputing Centre"
- LRZ [operates](https://www.lrz.de/services/netz/mwn-ueberblick_en/) the Munich Scientific Network (MWN) (`mwn.de`)
- LRZ provides services, including [identity management](https://www.it.tum.de/en/it/faq/it-dienste/leibniz-rechenzentrum-lrz/lrz/was-ist-die-lrz-kennung/) for TUM.
- tum.de and mytum.de both list "Technische Universitaet Muenchen" in the SSL Cert

Users may only update their central TUM account (managed by LRZ) password on `campus.tum.de`.

I hope I did not miss a link. If anything is unclear, please ask.