### PR TITLE
Add related domains to fix #574, #575, #580, #564, #568

### DIFF
--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -21,6 +21,12 @@
     },
     {
         "shared": [
+            "alibaba.com",
+            "aliexpress.com"
+        ]
+    },
+    {
+        "shared": [
             "alltrails.com",
             "alltrails.io"
         ]
@@ -44,7 +50,8 @@
             "amazon.sa",
             "amazon.sg",
             "amazon.se",
-            "amazon.pl"
+            "amazon.pl",
+            "ring.com"
         ]
     },
     {
@@ -77,6 +84,12 @@
         "shared": [
             "apple.com",
             "icloud.com"
+        ]
+    },
+    {
+        "shared": [
+            "atlassian.com",
+            "trello.com"
         ]
     },
     {
@@ -127,6 +140,18 @@
             "stowe.com",
             "vail.com",
             "whistlerblackcomb.com"
+        ]
+    },
+    {
+        "shared": [
+            "boingo.com",
+            "boingohotspot.com"
+        ]
+    },
+    {
+        "shared": [
+            "bol.com",
+            "kobo.com"
         ]
     },
     {
@@ -210,6 +235,12 @@
     },
     {
         "shared": [
+            "eurosport.no",
+            "eurosportplayer.com"
+        ]
+    },
+    {
+        "shared": [
             "facebook.com",
             "messenger.com"
         ]
@@ -218,6 +249,12 @@
         "shared": [
             "fandangonow.com",
             "fandango.com"
+        ]
+    },
+    {
+        "shared": [
+            "fidelity.com",
+            "fidelityinvestments.com"
         ]
     },
     {
@@ -249,6 +286,20 @@
         "shared": [
             "gogoair.com",
             "gogoinflight.com"
+        ]
+    },
+    {
+        "shared": [
+            "hbo.com",
+            "hbomax.com",
+            "hbonow.com"
+        ]
+    },
+    {
+        "shared": [
+            "igen.fr",
+            "watchgeneration.fr",
+            "macg.co"
         ]
     },
     {
@@ -351,6 +402,12 @@
     },
     {
         "shared": [
+            "neatorama.com",
+            "neatoshop.com"
+        ]
+    },
+    {
+        "shared": [
             "newyorker.com",
             "vanityfair.com"
         ]
@@ -372,8 +429,14 @@
     },
     {
         "shared": [
-            "norwegianreward.com",
-            "norwegian.com"
+            "norwegian.com",
+            "norwegianreward.com"
+        ]
+    },
+    {
+        "shared": [
+            "olo.com",
+            "olo.express"
         ]
     },
     {
@@ -399,8 +462,32 @@
     },
     {
         "shared": [
+            "qnap.com",
+            "myqnapcloud.com"
+        ]
+    },
+    {
+        "shared": [
+            "questdiagnostics.com",
+            "care360.com"
+        ]
+    },
+    {
+        "shared": [
+            "rocketaccount.com",
+            "rocketmortgage.com"
+        ]
+    },
+    {
+        "shared": [
             "scholarshare529.com",
             "secureaccountview.com"
+        ]
+    },
+    {
+        "shared": [
+            "scoutingevent.com",
+            "campreservation.com"
         ]
     },
     {
@@ -435,7 +522,8 @@
             "shopdisney.com",
             "go.com",
             "disneyplus.com",
-            "espn.com"
+            "espn.com",
+            "disneystore.com"
         ]
     },
     {
@@ -585,6 +673,18 @@
         "shared": [
             "wsj.com",
             "dowjones.com"
+        ]
+    },
+    {
+        "shared": [
+            "yahoo.com",
+            "flickr.com"
+        ]
+    },
+    {
+        "shared": [
+            "zixmail.net",
+            "zixmessagecenter.com"
         ]
     }
 ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -99,6 +99,10 @@
         "vons.com"
     ],
     [
+        "alibaba.com",
+        "aliexpress.com"
+    ],
+    [
         "alltrails.com",
         "alltrails.io"
     ],
@@ -120,7 +124,8 @@
         "amazon.sa",
         "amazon.sg",
         "amazon.se",
-        "amazon.pl"
+        "amazon.pl",
+        "ring.com"
     ],
     [
         "amcrestcloud.com",
@@ -143,6 +148,10 @@
     [
         "apple.com",
         "icloud.com"
+    ],
+    [
+        "atlassian.com",
+        "trello.com"
     ],
     [
         "att.com",
@@ -181,6 +190,14 @@
         "stowe.com",
         "vail.com",
         "whistlerblackcomb.com"
+    ],
+    [
+        "boingo.com",
+        "boingohotspot.com"
+    ],
+    [
+        "bol.com",
+        "kobo.com"
     ],
     [
         "boudinbakery.com",
@@ -227,6 +244,10 @@
         "discord.com"
     ],
     [
+        "discordmerch.com",
+        "discord.store"
+    ],
+    [
         "dish.com",
         "mydish.com",
         "dishnetwork.com"
@@ -270,6 +291,10 @@
         "ebay.vn"
     ],
     [
+        "eurosport.no",
+        "eurosportplayer.com"
+    ],
+    [
         "eventbrite.at",
         "eventbrite.be",
         "eventbrite.ca",
@@ -302,6 +327,10 @@
         "fandango.com"
     ],
     [
+        "fidelity.com",
+        "fidelityinvestments.com"
+    ],
+    [
         "flyblade.com",
         "blade.com"
     ],
@@ -325,6 +354,16 @@
     [
         "gogoair.com",
         "gogoinflight.com"
+    ],
+    [
+        "hbo.com",
+        "hbomax.com",
+        "hbonow.com"
+    ],
+    [
+        "igen.fr",
+        "watchgeneration.fr",
+        "macg.co"
     ],
     [
         "ikonpass.com",
@@ -363,6 +402,12 @@
         "lookmark.link"
     ],
     [
+        "lrz.de",
+        "mwn.de",
+        "mytum.de",
+        "tum.de"
+    ],
+    [
         "lufthansa.com",
         "miles-and-more.com"
     ],
@@ -397,6 +442,10 @@
         "optumrx.com"
     ],
     [
+        "neatorama.com",
+        "neatoshop.com"
+    ],
+    [
         "newyorker.com",
         "vanityfair.com"
     ],
@@ -417,8 +466,12 @@
         "nordaccount.com"
     ],
     [
-        "norwegianreward.com",
-        "norwegian.com"
+        "norwegian.com",
+        "norwegianreward.com"
+    ],
+    [
+        "olo.com",
+        "olo.express"
     ],
     [
         "pinterest.com",
@@ -459,8 +512,24 @@
         "protonvpn.com"
     ],
     [
+        "qnap.com",
+        "myqnapcloud.com"
+    ],
+    [
+        "questdiagnostics.com",
+        "care360.com"
+    ],
+    [
+        "rocketaccount.com",
+        "rocketmortgage.com"
+    ],
+    [
         "scholarshare529.com",
         "secureaccountview.com"
+    ],
+    [
+        "scoutingevent.com",
+        "campreservation.com"
     ],
     [
         "scribbr.com",
@@ -487,7 +556,8 @@
         "shopdisney.com",
         "go.com",
         "disneyplus.com",
-        "espn.com"
+        "espn.com",
+        "disneystore.com"
     ],
     [
         "slcl.overdrive.com",
@@ -619,5 +689,13 @@
     [
         "www.vistaprint.ca",
         "account.vistaprint.com"
+    ],
+    [
+        "yahoo.com",
+        "flickr.com"
+    ],
+    [
+        "zixmail.net",
+        "zixmessagecenter.com"
     ]
 ]


### PR DESCRIPTION
As well as hbonow.com and disneystore.com.

I spend time researching all of the domains and feel reasonably certain that at one point, historically,
they were related. The bar for historical domains is lower than active ones.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials-historical.json
- [x] You believe that the domains were associated at some point in the past and can explain that relationship
