### PR TITLE
Add quirk for tix.soundrink.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -671,6 +671,9 @@
     "thameswater.co.uk": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
+    "tix.soundrink.com": {
+        "password-rules": "minlength: 6; maxlength: 16;"
+    },
     "training.confluent.io": {
         "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%*@^_~];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="667" alt="CleanShot 2022-02-15 at 13 23 05@2x" src="https://user-images.githubusercontent.com/29067983/154135050-df0214af-0229-4d59-916d-4541aaed4b28.png">

<img width="691" alt="CleanShot 2022-02-15 at 13 22 49@2x" src="https://user-images.githubusercontent.com/29067983/154135065-b5ae2c2f-446c-4832-a81a-6955f8b75674.png">

I tried various passwords generated at https://developer.apple.com/password-rules/ and they all passed. There don't seem to be any other requirements; even a ridiculous password like `1111111111111111` would satisfy this site. 😢 
