### PR TITLE
Remove Cigna from password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -146,9 +146,6 @@
     "cigna.co.uk": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
     },
-    "cigna.com": {
-        "password-rules": "minlength: 8; maxlength: 12; required: upper; required: digit; required: [_!.&@]; allowed: lower;"
-    },
     "citi.com": {
         "password-rules": "minlength: 6; maxlength: 50; max-consecutive: 2; required: lower, upper; required: digit; allowed: [_!@$]"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -671,6 +671,9 @@
     "thameswater.co.uk": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
+    "tix.soundrink.com": {
+        "password-rules": "minlength: 6; maxlength: 16;"
+    },
     "training.confluent.io": {
         "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%*@^_~];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

I propose removing the rule for Cigna, as they have updated their requirements to be very general and any password manager shouldn't have a problem generating passwords anymore. The current rule is more harmful than helpful, as it limits things to specific characters and under 12 total.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ ] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

![CleanShot 2022-03-15 at 22 25 45@2x](https://user-images.githubusercontent.com/29067983/158511381-48160165-b2a1-4733-bc9d-4bc6003d0c06.png)

