### PR TITLE
Add shared website credentials for Coolblue to quirks

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -108,6 +108,13 @@
         ]
     },
     {
+        "shared": [
+            "coolblue.nl",
+            "coolblue.be",
+            "coolblue.de"
+        ]
+    },
+    {
         "from": [
             "discordapp.com"
         ],


### PR DESCRIPTION
This PR aims to add the relationship between different domains for Coolblue, a retailer that originated in the Netherlands but is currently also operating in Belgium and Germany. Since our website serves all our customers on the specific TLDs for their respective countries, the following domains are essentially equivalent (and all serve authentication pages without redirecting to a "main" domain, like in the example in the checklist):

- [coolblue.nl](https://www.coolblue.nl)
- [coolblue.be](https://www.coolblue.be)
- [coolblue.de](https://www.coolblue.de)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)