### PR TITLE
Add password rule for zara.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -758,6 +758,9 @@
     "zdf.de": {
         "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
     },
+    "zara.com": {        
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"    
+    },
     "zoom.us": {
         "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
     }


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

### Image showing password rules for zara.com
![Screen Shot 2022-03-24 at 9 45 53 PM](https://user-images.githubusercontent.com/69443738/160056053-705b3e30-b1f3-4df4-bde1-5a65caf502a4.png)

