### PR TITLE
Add shared credentials for PostNL

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -233,6 +233,12 @@
         ]
     },
     {
+        "shared": [
+            "postnl.nl",
+            "postnl.be"
+        ]
+    },
+    {
         "from": [
             "tvnow.de",
             "tvnow.at",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

This PR adds PostNL, the Dutch Postal Carrier, to the quirks list. PostNL operates in both NL and BE and has separate sites, but shared login credentials across [postnl.nl](postnl.nl) and [postnl.be](postnl.be)
### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [X] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [X] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [X] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.