### PR TITLE
Added location to change password for Roblox

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -106,6 +106,7 @@
     "redirect.pizza": "https://redirect.pizza/profile",
     "reelgood.com": "https://reelgood.com/account",
     "rejsekort.dk": "https://selvbetjening.rejsekort.dk/CWS/CustomerManagement/ChangePassword",
+    "roblox.com": "https://www.roblox.com/my/account#!/info",
     "ruc.dk": "https://pwrecovery.ruc.dk",
     "santahelenasaude.com.br": "https://www.santahelenasaude.com.br/beneficiario/#/alterar-senha",
     "saturn.de": "https://www.saturn.de/webapp/wcs/stores/servlet/MultiChannelMAChangePassword",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state