### PR TITLE
Update Citi password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -150,7 +150,7 @@
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
     },
     "citi.com": {
-        "password-rules": "minlength: 6; maxlength: 50; max-consecutive: 2; required: lower, upper; required: digit; allowed: [_!@$]"
+        "password-rules": "minlength: 8; maxlength: 64; max-consecutive: 2; required: lower, upper; required: digit; required: [~`!@#$%^&*()_-\/|];"
     },
     "claimlookup.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@#$%^&+=!];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -150,7 +150,7 @@
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
     },
     "citi.com": {
-        "password-rules": "minlength: 8; maxlength: 64; max-consecutive: 2; required: lower, upper; required: digit; required: [~`!@#$%^&*()_-\/|];"
+        "password-rules": "minlength: 8; maxlength: 64; max-consecutive: 2; required: lower, upper; required: digit; required: [-~`!@#$%^&*()_\/|];"
     },
     "claimlookup.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@#$%^&+=!];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship


From Citi bank's password change page:
```
Password Guidelines

    Different from your User ID
    No spaces
    No more than 2 consecutive identical characters
    Include between 8-64 characters
    No digital images or icons

Must Include:

    Include at least 1 number
    Include at least 1 uppercase letter
    Include at least 1 lowercase letter
    Include at least 1 special characters: ~ ` ! @ # $ % ^ & * ( ) _ - \ / |
```
![image](https://user-images.githubusercontent.com/4203943/166123489-a049ecd1-4c7f-429b-b603-7ffd73cbea29.png)

