### PR TITLE
Fix domain name

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -680,6 +680,9 @@
     "thameswater.co.uk": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
+    "thy.com" : {
+        "password-rules": "minlength: 6; maxlength: 6; max-consecutive: 2; required: digit; allowed: digit;"
+    },
     "tix.soundrink.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -680,7 +680,7 @@
     "thameswater.co.uk": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
-    "thy.com" : {
+    "turkishairlines.com" : {
         "password-rules": "minlength: 6; maxlength: 6; max-consecutive: 2; required: digit; allowed: digit;"
     },
     "tix.soundrink.com": {

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -683,14 +683,14 @@
     "thameswater.co.uk": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
-    "turkishairlines.com" : {
-        "password-rules": "minlength: 6; maxlength: 6; max-consecutive: 2; required: digit; allowed: digit;"
-    },
     "tix.soundrink.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },
     "training.confluent.io": {
         "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%*@^_~];"
+    },
+    "turkishairlines.com" : {
+        "password-rules": "minlength: 6; maxlength: 6; max-consecutive: 2; required: digit; allowed: digit;"
     },
     "twitter.com": {
         "password-rules": "minlength: 8;"

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -301,5 +301,11 @@
             "account.vistaprint.com"
         ],
         "fromDomainsAreObsoleted": true
+    },    
+    {
+        "shared" : [
+            "turkishairlines.com",
+            "thy.com"
+        ]
     }
 ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -245,6 +245,12 @@
         ]
     },
     {
+        "shared" : [
+            "thy.com",
+            "turkishairlines.com"
+        ]
+    },
+    {
         "from": [
             "tvnow.de",
             "tvnow.at",
@@ -301,11 +307,5 @@
             "account.vistaprint.com"
         ],
         "fromDomainsAreObsoleted": true
-    },    
-    {
-        "shared" : [
-            "turkishairlines.com",
-            "thy.com"
-        ]
     }
 ]


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ ] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [ ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
