### PR TITLE
Remove bol.com/kobo.com from shared list

### DIFF
--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -196,10 +196,6 @@
         "boingohotspot.com"
     ],
     [
-        "bol.com",
-        "kobo.com"
-    ],
-    [
         "boudinbakery.com",
         "boudincatering.com"
     ],


### PR DESCRIPTION
https://github.com/apple/password-manager-resources/issues/580 introduced a shared backend quirk for bol.com and kobo.com.
Bol.com and kobo.com are separate entities, kobo.com merely consumes bol.com's oAuth2 implementation.
Login via bol.com lives on login.bol.com only, credentials will never have to be entered in kobo.com's separate backend.
Users re-using the same password for bol.com and kobo.com are simply not adhering to password best practices.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
