### PR TITLE
Add password rules for ccs-grp.com (resolves #610)

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -140,6 +140,9 @@
     "cb2.com": {
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },
+    "ccs-grp.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower; allowed: [-!#$%&'+./=?\\^_`{|}~];"
+    },
     "cecredentialtrust.com": {
         "password-rules": "minlength: 12; required: lower; required: upper; required: digit; required: [!#$%&*@^];"
     },


### PR DESCRIPTION
Resolves #610.

### Explanation of rules

```
minlength: 8; required: digit; required: upper,lower;
```
These rules were collected through information provided on the website before submitting the form.

<img width="614" alt="Screenshot 2022-05-29 at 15 56 47" src="https://user-images.githubusercontent.com/1858562/170875938-9e316488-0531-40e3-a023-c9bc24c6e489.png">

```
maxlength: 16;
```
This rule was collected from the error text displayed after submitting a password that was over the limit.

<img width="614" alt="Screenshot 2022-05-29 at 15 41 46" src="https://user-images.githubusercontent.com/1858562/170876051-d8b68473-eea4-4618-965f-539cc8740e45.png">

```
allowed: [-!#$%&'+./=?\\^_`{|}~];
```

This rule was gathered by testing each symbol (``/\_-~ !@#$%^&*+=`|(){}[]:;"'<>,.?``) one by one in an otherwise valid password. The website would throw the same error as above, which didn't mention anything about invalid symbols.

The invalid symbols are `` @%*+=`|()[]:;"<>,``

Resolves 

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)