### PR TITLE
Add a password rule for citiretailservices.citibankonline.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -155,6 +155,9 @@
     "citi.com": {
         "password-rules": "minlength: 6; maxlength: 50; max-consecutive: 2; required: lower, upper; required: digit; allowed: [_!@$]"
     },
+    "citiretailservices.citibankonline.com": {
+        "password-rules": "minlength: 6; maxlength: 32; required: lower, upper; required: digit; required: digit; allowed: [-!@#$%^*_+{}.?[]];"
+    },
     "claimlookup.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@#$%^&+=!];"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

I wanted to give the password rules for _citiretailservices.citibankonline.com_ a go. The rules differ from _citi.com_ (#605). Password rules for Citi retail services seem to appear in two issues, #585 and #611. I have copied over the screenshot and video showing the password rules from the respective issues.

<img alt="screenshot of password rules for citiretailservices.citibankonline.com" src="https://github.com/assets/59782525/a9e538ea-222b-4440-b3c6-6d85de3a8850" width=500>

https://user-images.githubusercontent.com/105558862/168441873-ccf6cf08-7a87-437b-a3ef-74122fd88fbc.MOV

### Rules 

Here is a textual version of the rules:

>**Password Requirements**
• Between 6 and 32 characters
• Include 1 letter and 2 numbers
• Cannot include 2 spaces in a row
• Cannot use special characters (~ , & , ( , ) , “ , < , > , ` , = , ‘ , : , ; , / , \ , | or ,)
• Must be different from User ID
• Different from your existing password and does not match any of your last 6 passwords

### Additional quirks

- The password rules demand that two spaces should not appear consecutively. I could not find a way to express that in the password rules language. To avoid specifying a general `max-consecutive: 2`, I decided to not include `space` in the `allowed` custom character class.

- The password rules disallow a good number of special characters. I have added all the `special` characters specified in the [customizing password autofill rules documentation](https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules) that were not explicitly disallowed by the password rules.

<hr>

> 🚨 Note: I am not able to test the passwords generated by the [Password Rules Validation Tool](https://developer.apple.com/password-rules/) myself, as I do not have an account with Citi retail services. 

@snicolai-blog and @jcordeal, would you be able to help test the validity of the new password rule?

Thanks in advance :)

Closes #585
Closes #611 