### PR TITLE
[Proposal] Add schemas and validate all the quirks JSON files. 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Lint Valid Json
       run: |
-        find quirks/ -name '*.json' -print0 | while IFS= read -r -d '' filename; do 
+        find quirks/ -name '*.json' -print0 -maxdepth 1 | while IFS= read -r -d '' filename; do
           echo "Validating $(basename "$filename")"
           python -mjson.tool "$filename" > /dev/null
         done
@@ -40,3 +40,13 @@ jobs:
       run: ruby .github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
     - name: Lint Duplicates
       run: ruby .github/workflows/lint-scripts/websites-shared-credentials-duplicates.rb
+
+  validate-schemas:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v3
+    - name: Install ajv-cli
+      run: npm install -g ajv-cli
+    - name: Validate quirk JSONs against the schemas
+      run: ./tools/validate-json-schemas.sh

--- a/quirks/schemas/change-password-URLs-schema.json
+++ b/quirks/schemas/change-password-URLs-schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": {
+    "type": "string"
+  }
+}

--- a/quirks/schemas/password-rules-schema.json
+++ b/quirks/schemas/password-rules-schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "password-rules": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "password-rules"
+    ]
+  }
+}

--- a/quirks/schemas/shared-credentials-historical-schema.json
+++ b/quirks/schemas/shared-credentials-historical-schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "definitions": {
+    "domain-list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "type": "array",
+  "items": {
+    "oneOf": [
+      {
+        "type": "object",
+        "properties": {
+          "shared": {
+            "$ref": "#/definitions/domain-list"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "shared"
+        ]
+      },
+      {
+        "type": "object",
+        "properties": {
+          "from": {
+            "$ref": "#/definitions/domain-list"
+          },
+          "to": {
+            "$ref": "#/definitions/domain-list"
+          },
+          "fromDomainsAreObsoleted": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "from",
+          "to"
+        ]
+      }
+    ]
+  }
+}

--- a/quirks/schemas/shared-credentials-schema.json
+++ b/quirks/schemas/shared-credentials-schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "definitions": {
+    "domain-list": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "type": "array",
+  "items": {
+    "oneOf": [
+      {
+        "type": "object",
+        "properties": {
+          "shared": {
+            "$ref": "#/definitions/domain-list"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "shared"
+        ]
+      },
+      {
+        "type": "object",
+        "properties": {
+          "from": {
+            "$ref": "#/definitions/domain-list"
+          },
+          "to": {
+            "$ref": "#/definitions/domain-list"
+          },
+          "fromDomainsAreObsoleted": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "from",
+          "to"
+        ]
+      }
+    ]
+  }
+}

--- a/quirks/schemas/websites-that-append-2fa-to-password-schema.json
+++ b/quirks/schemas/websites-that-append-2fa-to-password-schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "uniqueItems": true,
+  "items": {
+    "type": "string"
+  }
+}

--- a/quirks/schemas/websites-with-shared-credential-backends-schema.json
+++ b/quirks/schemas/websites-with-shared-credential-backends-schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "array",
+    "uniqueItems": true,
+    "items": {
+      "type": "string"
+    },
+    "minItems": 1
+  }
+}

--- a/tools/validate-json-schemas.sh
+++ b/tools/validate-json-schemas.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v ajv &> /dev/null
+then
+    echo "The 'ajv' command is required, please install the 'ajv-cli' package"
+    exit 1
+fi
+
+# Finds all JSON files in the quirks directory and validates them against the corresponding schema.
+find quirks -name '*.json' -print0 -maxdepth 1 | while IFS= read -r -d '' filename; do
+    schema="quirks/schemas/$(basename "$filename" .json)-schema.json"
+    echo "Validating $filename against $schema"
+    ajv -s "$schema" -d "$filename" --spec=draft2020
+done


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

This is a proposal with an implementation for adding JSON schemas for each of the JSON file under the `quirks` directory. The JSON schemas allow us to formalize the structure of the JSON and run tools to validate the corresponding JSON files. This PR also adds a workflow to run the validation on the CI.