### PR TITLE
Add lepida.it to password-rules.json

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -423,7 +423,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
     "lepida.it": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-~!@#$%^&*_+=`|(){}[:;"'<>,.?]]; max-consecutive: 2;"  
+        "password-rules": "minlength: 8; maxlength: 16; max-consecutive: 2; required: lower; required: upper; required: digit; required: [-!\"#$%&'()*+,.:;<=>?@[^_`{|}~]];"  
     },
     "lg.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-!#$%&'()*+,.:;=?@[^_{|}~]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -422,6 +422,9 @@
     "leetchi.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
+    "lepida.it": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"  
+    },
     "lg.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-!#$%&'()*+,.:;=?@[^_{|}~]];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -423,7 +423,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
     "lepida.it": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-~!@#$%^&*_+=`|(){}[:;"'<>,.?]]; max-consecutive: 2"  
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-~!@#$%^&*_+=`|(){}[:;"'<>,.?]]; max-consecutive: 2;"  
     },
     "lg.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-!#$%&'()*+,.:;=?@[^_{|}~]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -423,7 +423,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
     "lepida.it": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"  
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-~!@#$%^&*_+=`|(){}[:;"'<>,.?]]; max-consecutive: 2"  
     },
     "lg.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-!#$%&'()*+,.:;=?@[^_{|}~]];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)


<img width="667" alt="Screenshot 2022-06-30 at 14 48 35" src="https://user-images.githubusercontent.com/1105813/176680768-9f24cc88-585a-46de-a926-1b3acaca6016.png">

