### PR TITLE
Add password-rules quirks for twitch.tv

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -701,6 +701,9 @@
     "twitter.com": {
         "password-rules": "minlength: 8;"
     },
+    "twitch.tv": {
+        "password-rules": "minlength: 8; maxlength: 71;"
+    },
     "ubisoft.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-]; required: [!@#$%^&*()+];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -698,11 +698,11 @@
     "training.confluent.io": {
         "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%*@^_~];"
     },
-    "twitter.com": {
-        "password-rules": "minlength: 8;"
-    },
     "twitch.tv": {
         "password-rules": "minlength: 8; maxlength: 71;"
+    },
+    "twitter.com": {
+        "password-rules": "minlength: 8;"
     },
     "ubisoft.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-]; required: [!@#$%^&*()+];"


### PR DESCRIPTION


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

# Summary

Twitch.tv for some reason rejects passwords longer than 71 characters as I discovered while trying to reset my password yesterday. This is relevant information because some password managers (including Bitwarden, which I use) generate passwords up to 128 characters in length.

I was directed here by a friend after ranting on Twitter about it:
https://twitter.com/thomasfuller98/status/1543023228607557632

# Testing + Results

(No passwords here are used by me for real accounts, nor should they be used by anyone from now on)

## Password of length 128:
y4Gyy7%sk9q2boM&C5@btRu#enpw&6Nzdwgo6pzVVXRFx7NKmmnm#SKyNo!sa@$4vEiPk6zpruL^s&U%pKvZk@VMxknhE#zn#hYZ%848EEmCpsJwvmiYjbgg2b$E3V5S

![Screen Shot 2022-07-03 at 1 34 40 PM](https://user-images.githubusercontent.com/16064438/177056390-0a2dc25e-3253-4468-96ec-b47ea6217e8d.png)

## Password of length 72:

aJTq7i3QEk$@ehXf!#cSJoT@@MSn23mNj7TE$dJUsVnYRK%%LorU$ZoS8&DwCY5ng&wN39y2

![Screen Shot 2022-07-03 at 1 34 19 PM](https://user-images.githubusercontent.com/16064438/177056381-7dabfa1b-5ee0-44ce-9bf3-cddbcdd78936.png)

## Password of length 71:
*QmjzXFQqzoou%NGTdH2uf4sTdQuG$mmAaoqHCwxLxCbDd4FmcRDNjdG8$U7UY3N*FKXdM*

![Screen Shot 2022-07-03 at 1 34 03 PM](https://user-images.githubusercontent.com/16064438/177056375-9b8fe408-ce3f-40eb-aba2-b1f808d044ba.png)

## Password of length 16:

L6$*Xt@bvNYHX94g

![Screen Shot 2022-07-03 at 1 33 38 PM](https://user-images.githubusercontent.com/16064438/177056367-ca8235b5-d443-4114-a82e-855d59cec9fd.png)


## Password of length 8

r&!5E#Nc

![Screen Shot 2022-07-03 at 1 31 53 PM](https://user-images.githubusercontent.com/16064438/177056304-d3e648f7-fa2f-4364-92ac-bbb31b4eb274.png)

Password of length 7:

WDT$4q4

![Screen Shot 2022-07-03 at 1 33 08 PM](https://user-images.githubusercontent.com/16064438/177056352-23b48180-b257-4505-99dc-1c99dd704b8a.png)

