### PR TITLE
Add password-rules for carrefour.it 

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -137,7 +137,7 @@
     "cardbenefitservices.com": {
         "password-rules": "minlength: 7; maxlength: 100; required: lower, upper; required: digit;"
     },
-    "carrefour.it" {
+    "carrefour.it": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
     },
     "cb2.com": {

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -137,6 +137,9 @@
     "cardbenefitservices.com": {
         "password-rules": "minlength: 7; maxlength: 100; required: lower, upper; required: digit;"
     },
+    "carrefour.it" {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
+    },
     "cb2.com": {
         "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

https://www.carrefour.it/account/register

<img width="955" alt="Screenshot 2022-09-09 at 12 51 17" src="https://user-images.githubusercontent.com/1105813/189334266-7742ddfb-a66c-4096-9a13-b39f44c126eb.png">

