### PR TITLE
PasswordRulesParser.js copyright year update

### DIFF
--- a/tools/PasswordRulesParser.js
+++ b/tools/PasswordRulesParser.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 - 2021 Apple Inc. Licensed under MIT License.
+// Copyright (c) 2019 - 2022 Apple Inc. Licensed under MIT License.
 
 "use strict";
 


### PR DESCRIPTION
### Overall Checklist
- [ x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [ x] The top-level JSON objects are sorted alphabetically
- [ x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

Reason: File PasswordRulesParser.js has outdated copyright year