### PR TITLE
Password rules airfrance

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -20,12 +20,6 @@
     "airasia.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
-    "airfrance.com": {
-        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
-    },
-    "airfrance.us": {
-        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
-    },
     "ajisushionline.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [ !#$%&*?@];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -20,6 +20,12 @@
     "airasia.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
+    "airfrance.com": {
+        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
+    },
+    "airfrance.us": {
+        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
+    },
     "ajisushionline.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [ !#$%&*?@];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x ] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [ x] The top-level JSON objects are sorted alphabetically
- [ x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ x] The given rule isn't particularly standard and obvious for password managers
- [x ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [ x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Reason: airfrance.com/.us has specific length limitation 8-12 characters.

<img width="1399" alt="Screenshot 2022-11-08 at 16 50 44" src="https://user-images.githubusercontent.com/35962122/200709149-3a21f04e-ca40-40bb-bda5-97090a75d52c.png">
