### PR TITLE
nebula.app to nebula.tv

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -236,6 +236,15 @@
     },
     {
         "from": [
+            "nebula.app"
+        ],
+        "to": [
+            "nebula.tv"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "nordvpn.com",
             "nordpass.com"
         ],

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -236,7 +236,8 @@
     },
     {
         "from": [
-            "nebula.app"
+            "nebula.app",
+            "watchnebula.com"
         ],
         "to": [
             "nebula.tv"

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -244,6 +244,10 @@
         "vulture.com"
     ],
     [
+        "dan.org",
+        "diversalertnetwork.org"
+    ],
+    [
         "dinersclubnorthamerica.com",
         "dinersclubus.com"
     ],
@@ -465,6 +469,11 @@
     [
         "neatorama.com",
         "neatoshop.com"
+    ],
+    [
+        "nebula.app",
+        "watchnebula.com",
+        "nebula.tv"
     ],
     [
         "newyorker.com",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] ~~If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)~~
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
