### PR TITLE
Add obsoleted domain entries for Nebula.

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -214,6 +214,16 @@
     },
     {
         "from": [
+            "nebula.app",
+            "watchnebula.com"
+        ],
+        "to": [
+            "nebula.tv"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "nordvpn.com",
             "nordpass.com"
         ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -463,6 +463,11 @@
         "neatoshop.com"
     ],
     [
+        "nebula.app",
+        "watchnebula.com",
+        "nebula.tv"
+    ],
+    [
         "newyorker.com",
         "vanityfair.com"
     ],


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### Evidence

- The SSL certificate for [nebula.tv](https://nebula.tv) lists [watchnebula.com](https://watchnebula.com) and [nebula.app](https://nebula.app) in the "Subject Alternative Name" field
<details>

<summary>SSL certificate for <a href="https://nebula.tv">nebula.tv</a></summary>

```
depth=2 C = US, O = Amazon, CN = Amazon Root CA 1
verify return:1
depth=1 C = US, O = Amazon, OU = Server CA 1B, CN = Amazon
verify return:1
depth=0 CN = nebula.tv
verify return:1
poll errorCertificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            05:31:ea:f1:83:09:82:a6:f1:4f:f5:72:72:72:25:be
    Signature Algorithm: sha256WithRSAEncryption
        Issuer: C=US, O=Amazon, OU=Server CA 1B, CN=Amazon
        Validity
            Not Before: Aug 11 00:00:00 2022 GMT
            Not After : Sep  9 23:59:59 2023 GMT
        Subject: CN=nebula.tv
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                RSA Public-Key: (2048 bit)
                Modulus:
                    00:a3:41:13:42:73:c8:57:9d:3b:11:be:c8:00:b6:
                    11:30:b4:f7:ae:0f:13:cc:2b:54:3f:1f:3e:fd:f8:
                    0d:a6:7d:8b:bb:4e:cb:63:ef:22:b2:14:58:bf:43:
                    1c:ce:92:9e:2e:70:88:7b:4f:67:05:1c:b0:d9:c2:
                    78:f9:71:d7:2b:33:51:c8:db:f0:dc:20:57:9a:dc:
                    99:b4:ce:16:d3:c1:78:28:ff:d4:32:f1:f9:8a:03:
                    a7:09:d2:fd:d5:3a:ee:9d:02:57:64:7a:3c:86:d7:
                    c1:b5:80:17:05:4c:82:dd:b0:0a:eb:e2:b8:4a:20:
                    e4:d2:e6:06:46:88:7f:42:0b:05:5c:bf:9c:17:86:
                    f0:e3:85:0a:46:81:59:dd:59:d9:73:39:9e:69:80:
                    d8:2a:2e:d5:67:32:e8:c9:ce:72:98:56:46:a2:25:
                    02:b5:83:f9:60:1d:8a:ec:24:c9:c4:b0:42:6b:c9:
                    6c:76:32:d6:a7:f2:eb:d3:60:cb:b2:e3:51:d1:43:
                    65:54:66:a6:e2:29:27:84:9d:f6:52:b6:95:14:b1:
                    10:fc:a9:18:ba:a3:87:95:f5:03:8f:65:93:d9:5c:
                    ad:2a:68:8f:aa:cd:e9:23:e4:df:84:2d:71:3b:84:
                    c3:5e:41:48:11:31:e5:cc:76:1e:29:d4:04:fb:62:
                    d0:59
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Authority Key Identifier: 
                keyid:59:A4:66:06:52:A0:7B:95:92:3C:A3:94:07:27:96:74:5B:F9:3D:D0

            X509v3 Subject Key Identifier: 
                2E:AA:9F:40:66:B9:E0:A5:3A:4A:93:AE:E2:C7:52:4E:30:95:3C:59
            X509v3 Subject Alternative Name: 
                DNS:nebula.tv, DNS:nebula.app, DNS:*.nebula.tv, DNS:*.watchnebula.com, DNS:*.api.nebula.tv, DNS:*.nebula.app, DNS:*.qa.nebula.app, DNS:*.api.nebula.app, DNS:*.qa.nebula.tv
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 CRL Distribution Points: 

                Full Name:
                  URI:http://crl.sca1b.amazontrust.com/sca1b-1.crl

            X509v3 Certificate Policies: 
                Policy: 2.23.140.1.2.1

            Authority Information Access: 
                OCSP - URI:http://ocsp.sca1b.amazontrust.com
                CA Issuers - URI:http://crt.sca1b.amazontrust.com/sca1b.crt

            X509v3 Basic Constraints: critical
                CA:FALSE
            1.3.6.1.4.1.11129.2.4.2: 
                ...j.h.w..>..>..52.W(..k......k..i.w}m..n......iq.....H0F.!..=.eY....FOM6.#"..........l..`.,.!...q..........L..
.d?9.6.+KZFl..l.u.5.....lW...LmB...' &Q.?.*....;.L......i......F0D. (6.I.L.......i......:.t.
.....#.. n;.....CR..^*....,/..l.G'/].@.mR.v..>.$..M.u.9..X.l].B.z.5.....%.........i......G0E.!..Y..-........E.....d....S.i.dvB.. /.(.....*..h.B..r../.)..r...
..@
    Signature Algorithm: sha256WithRSAEncryption
         15:5f:c9:27:c3:93:6d:eb:88:fd:fb:11:f7:dc:0e:ea:9a:bf:
         fd:74:0a:e2:a0:45:ee:b0:8b:4a:e4:ea:16:45:d8:18:00:d9:
         8f:ae:67:7b:5c:e5:cd:4f:6c:d5:21:ce:27:f3:51:ee:c2:27:
         1c:7f:8d:34:40:6d:ff:17:76:5c:2e:d9:af:05:af:d9:5e:fe:
         49:14:de:e2:17:67:a3:f0:14:87:cb:01:88:55:14:54:a2:2d:
         9e:e2:4b:b9:fa:07:8d:3d:8a:9e:52:56:1e:73:10:f0:0a:db:
         ae:ce:3a:d2:2b:89:27:ec:f1:d8:bb:1d:cc:66:3d:b5:bc:c0:
         5f:2c:c6:cb:45:91:06:27:81:c6:51:05:bf:ab:70:83:42:58:
         e9:15:30:66:83:89:d5:90:b2:6d:74:4f:a8:7f:46:6c:44:78:
         21:98:3a:5d:f9:51:f0:1a:e6:1f:76:d6:46:e3:1d:94:0f:71:
         b2:b4:6c:7d:75:fb:07:c3:8a:43:a7:38:39:07:97:b9:ad:10:
         6e:75:f1:c6:54:15:ba:62:82:38:4f:d5:67:94:bf:59:78:60:
         e0:88:3d:ec:f2:1a:77:8d:83:26:51:d8:77:4c:cd:5e:59:46:
         32:2a:5e:c8:fa:64:98:ff:a0:45:10:96:8c:d1:d2:ef:41:8e:
         10:94:3b:1c
-----BEGIN CERTIFICATE-----
MIIGSzCCBTOgAwIBAgIQBTHq8YMJgqbxT/VycnIlvjANBgkqhkiG9w0BAQsFADBG
MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2ZXIg
Q0EgMUIxDzANBgNVBAMTBkFtYXpvbjAeFw0yMjA4MTEwMDAwMDBaFw0yMzA5MDky
MzU5NTlaMBQxEjAQBgNVBAMTCW5lYnVsYS50djCCASIwDQYJKoZIhvcNAQEBBQAD
ggEPADCCAQoCggEBAKNBE0JzyFedOxG+yAC2ETC0964PE8wrVD8fPv34DaZ9i7tO
y2PvIrIUWL9DHM6Sni5wiHtPZwUcsNnCePlx1yszUcjb8NwgV5rcmbTOFtPBeCj/
1DLx+YoDpwnS/dU67p0CV2R6PIbXwbWAFwVMgt2wCuviuEog5NLmBkaIf0ILBVy/
nBeG8OOFCkaBWd1Z2XM5nmmA2Cou1Wcy6MnOcphWRqIlArWD+WAdiuwkycSwQmvJ
bHYy1qfy69Ngy7LjUdFDZVRmpuIpJ4Sd9lK2lRSxEPypGLqjh5X1A49lk9lcrSpo
j6rN6SPk34QtcTuEw15BSBEx5cx2HinUBPti0FkCAwEAAaOCA2UwggNhMB8GA1Ud
IwQYMBaAFFmkZgZSoHuVkjyjlAcnlnRb+T3QMB0GA1UdDgQWBBQuqp9AZrngpTpK
k67ix1JOMJU8WTCBlAYDVR0RBIGMMIGJggluZWJ1bGEudHaCCm5lYnVsYS5hcHCC
CyoubmVidWxhLnR2ghEqLndhdGNobmVidWxhLmNvbYIPKi5hcGkubmVidWxhLnR2
ggwqLm5lYnVsYS5hcHCCDyoucWEubmVidWxhLmFwcIIQKi5hcGkubmVidWxhLmFw
cIIOKi5xYS5uZWJ1bGEudHYwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsG
AQUFBwMBBggrBgEFBQcDAjA9BgNVHR8ENjA0MDKgMKAuhixodHRwOi8vY3JsLnNj
YTFiLmFtYXpvbnRydXN0LmNvbS9zY2ExYi0xLmNybDATBgNVHSAEDDAKMAgGBmeB
DAECATB1BggrBgEFBQcBAQRpMGcwLQYIKwYBBQUHMAGGIWh0dHA6Ly9vY3NwLnNj
YTFiLmFtYXpvbnRydXN0LmNvbTA2BggrBgEFBQcwAoYqaHR0cDovL2NydC5zY2Ex
Yi5hbWF6b250cnVzdC5jb20vc2NhMWIuY3J0MAwGA1UdEwEB/wQCMAAwggF+Bgor
BgEEAdZ5AgQCBIIBbgSCAWoBaAB3AOg+0No+9QY1MudXKLyJa8kD08vREWvs62nh
d31tBr1uAAABgo35aXEAAAQDAEgwRgIhAMA90WVZ84wDmUZPTTa3IyLG3tH/1666
mfPBbLu1YIksAiEAyoxx9YPVhoK48rLuH0zjvgqyZD85DzbhK0taRmz4o2wAdQA1
zxkbv7FsV78PrUxtQsu7ticgJlHqP+Eq76gDwzvWTAAAAYKN+WmpAAAEAwBGMEQC
ICg21UnPTPS16c2LvgNp/Kv4H479Otd0iQoW3KCT8yOkAiBuO5MI94WbQ1KJHl4q
tLux3SwvkQds30cnL12aQAZtUgB2ALc++yTfnE26dfI5xbpY9Gxd/ELPep81xJ4d
CYEl7bSZAAABgo35aZwAAAQDAEcwRQIhAKFZBogtn9vt19aOqPlF4+j/jJVk86cX
C1PKaYpkdkIEAiAvoiih172c4ip/9GjlQpyBctbOL7gpEA5yrgizCoSSQDANBgkq
hkiG9w0BAQsFAAOCAQEAFV/JJ8OTbeuI/fsR99wO6pq//XQK4qBF7rCLSuTqFkXY
GADZj65ne1zlzU9s1SHOJ/NR7sInHH+NNEBt/xd2XC7ZrwWv2V7+SRTe4hdno/AU
h8sBiFUUVKItnuJLufoHjT2KnlJWHnMQ8Arbrs460iuJJ+zx2LsdzGY9tbzAXyzG
y0WRBieBxlEFv6twg0JY6RUwZoOJ1ZCybXRPqH9GbER4IZg6XflR8BrmH3bWRuMd
lA9xsrRsfXX7B8OKQ6c4OQeXua0QbnXxxlQVumKCOE/VZ5S/WXhg4Ig97PIad42D
JlHYd0zNXllGMipeyPpkmP+gRRCWjNHS70GOEJQ7HA==
-----END CERTIFICATE-----
``` 

</details>

- [watchnebula.com](https://watchnebula.com) and [nebula.app](https://nebula.app) redirect to [nebula.tv](https://nebula.tv).
