### PR TITLE
Remove minecraft.com password rules

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -80,8 +80,6 @@
     "meliuz.com.br": "https://www.meliuz.com.br/minha-conta/meus-dados/senha",
     "messagebird.com": "https://dashboard.messagebird.com/account/security",
     "microsoft.com": "https://account.live.com/password/Change",
-    "minecraft.net": "https://www.minecraft.net/profile",
-    "mojang.com": "https://www.minecraft.net/profile",
     "myaccount.ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "myaccount.google.com": "https://myaccount.google.com/signinoptions/password",
     "naver.com": "https://nid.naver.com/user2/help/myInfo.nhn?m=viewChangePasswd",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -435,7 +435,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&()*+,./:;<>?@\"_];"
     },
     "lepida.it": {
-        "password-rules": "minlength: 8; maxlength: 16; max-consecutive: 2; required: lower; required: upper; required: digit; required: [-!\"#$%&'()*+,.:;<=>?@[^_`{|}~]];"  
+        "password-rules": "minlength: 8; maxlength: 16; max-consecutive: 2; required: lower; required: upper; required: digit; required: [-!\"#$%&'()*+,.:;<=>?@[^_`{|}~]];"
     },
     "lg.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-!#$%&'()*+,.:;=?@[^_{|}~]];"
@@ -481,9 +481,6 @@
     },
     "microsoft.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
-    },
-    "minecraft.com": {
-        "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: ascii-printable;"
     },
     "mintmobile.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

There are two reasons for removing this:

- `minecraft.com` redirects to `minecraft.net`, so this is the wrong domain anyways
- `minecraft.net` profiles must be migrated to `microsoft.com` profiles, so it is no longer possible to set a password on this domain

I have also removed the password changing URLs for `mojang.com` and `minecraft.net` because it is no longer possible to change those account passwords. They must be migrated to `microsoft.net` accounts.