### PR TITLE
Added the UK Nintendo store

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -661,7 +661,7 @@
     },
     "store.nintendo.co.uk": {
         "password-rules": "minlength: 8; maxlength: 20;"
-    }
+    },
     "signin.ea.com": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -659,6 +659,9 @@
     "sfwater.org": {
         "password-rules": "minlength: 10; maxlength: 30; required: digit; allowed: lower, upper, [!@#$%*()_+^}{:;?.];"
     },
+    "store.nintendo.co.uk": {
+        "password-rules": "minlength: 8; maxlength: 20;"
+    }
     "signin.ea.com": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -659,9 +659,6 @@
     "sfwater.org": {
         "password-rules": "minlength: 10; maxlength: 30; required: digit; allowed: lower, upper, [!@#$%*()_+^}{:;?.];"
     },
-    "store.nintendo.co.uk": {
-        "password-rules": "minlength: 8; maxlength: 20;"
-    },
     "signin.ea.com": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
@@ -679,6 +676,9 @@
     },
     "ssa.gov": {
         "password-rules": "required: lower; required: upper; required: digit; required: [~!@#$%^&*];"
+    },
+    "store.nintendo.co.uk": {
+        "password-rules": "minlength: 8; maxlength: 20;"
     },
     "store.nvidia.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit; required: [-!@#$%^*~:;&><[{}|_+=?]];"


### PR DESCRIPTION
https://store.nintendo.co.uk/ has a max-length of 20. min-length of 8

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [ ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
