### PR TITLE
Add spirit.com to shared-credentials-historical

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -20,12 +20,6 @@
     "airasia.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
-    "airfrance.com": {
-        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
-    },
-    "airfrance.us": {
-        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
-    },
     "ajisushionline.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [ !#$%&*?@];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -20,6 +20,12 @@
     "airasia.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
+    "airfrance.com": {
+        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
+    },
+    "airfrance.us": {
+        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
+    },
     "ajisushionline.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [ !#$%&*?@];"
     },

--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -536,6 +536,12 @@
     },
     {
         "shared": [
+            "spirit.com",
+            "spirit-airlines.com"
+        ]
+    },
+    {
+        "shared": [
             "springfield.overdrive.com",
             "coolcat.org"
         ]


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials-historical.json
- [x] You believe that the domains were associated at some point in the past and can explain that relationship

Reason: spirit-airlines.com redirects to spirit.com