### PR TITLE
Add password rule for treasurer.mo.gov

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -713,6 +713,9 @@
     "training.confluent.io": {
         "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%*@^_~];"
     },
+    "treasurer.mo.gov": {
+        "password-rules": "minlength: 8; maxlength: 26; required: lower; required: upper; required: digit; required: [!#$&];"
+    },
     "twitch.tv": {
         "password-rules": "minlength: 8; maxlength: 71;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

If you want to test these rules, the registration page is here: https://www.treasurer.mo.gov/UnclaimedProperty/en/Claimant/Register

The stated password rules are:
>  Passwords must be between 8 and 26 characters and contain at least one special character (e.g. $,\&.#!). Passwords must have at least one digit (‘0’-‘9’) and at least one uppercase (‘A’-Z’) 

but those do not seem to be the actual rules.

For example it doesn't say a lower case character is required but a password like `J!QK47YVCRB3JV` that has no lower case characters but meets the other requirements is not allowed.

They also list some special characters that they don't actually count as special characters in practice. For example the password `j.QK47YVCRB3JV` is not allowed despite period being on the list of example special characters. From the example list, only `!#$&` are actually counted as special characters. Other characters that are not on the list like `%` and `*` do count as special characters but I did not include them on the required list since they don't list those in the example.
 
