### PR TITLE
Add authenticate.seek domains to shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -108,6 +108,15 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "from": [
+            "authenticate.seek.com.au"
+        ],
+        "to": [
+            "authenticate.seek.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "centralfcu.org",
             "centralfcu.com"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

`talent.seek.com.au` is now using `authenticate.seek.com` for authentication, it previously used `authenticate.seek.com.au`.
The old domain does not redirect to the new domain, as it is now obsolete and no longer linked to. But you can see that this assetlinks file has a similar association to the one suggested in this PR https://authenticate.seek.com/.well-known/assetlinks.json