### PR TITLE
Add password-rules for member.everbridge.net (#658)

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -479,6 +479,9 @@
     "medicare.gov": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
     },
+    "member.everbridge.net": {
+        "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
+    },
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"
     },


### PR DESCRIPTION
This one website hosts accounts for many different organizations, but they all have the same password rules based on a pseudo-random sampling of "Sign Up" pages.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
