### PR TITLE
Add password rule for Boston Public Library Bibliocommons PIN

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -134,6 +134,9 @@
     "brighthorizons.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },
+    "bpl.bibliocommons.com": {
+        "password-rules": "minlength: 4; maxlength: 4; required: digit;"
+    }
     "callofduty.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: lower, upper; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -131,12 +131,12 @@
     "box.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },
+    "bpl.bibliocommons.com": {
+        "password-rules": "minlength: 4; maxlength: 4; required: digit;"
+    },
     "brighthorizons.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },
-    "bpl.bibliocommons.com": {
-        "password-rules": "minlength: 4; maxlength: 4; required: digit;"
-    }
     "callofduty.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: lower, upper; required: digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

The Boston Public Library's online portal requires a 4-digit PIN. Annoyingly, although there are a [ton](https://www.bibliocommons.com/about/libraries/united-states) of libraries at {libraryname}.bibliocommons.com, from clicking through to a couple of different login pages it appears that some require PINs and some allow real passwords, meaning we can't just add a blanket rule for bibliocommons.com. I added BPL here since that's the one I encountered, but for completeness we'd have to go through that whole list and check each library's rules individually. Ugh.

For reference, here's the message on the change password page:
<img width="413" alt="Screenshot 2023-01-09 at 10 37 25 AM" src="https://user-images.githubusercontent.com/16441122/211349923-5049365f-a5ed-4282-ab8a-426399912993.png">

It's not clear from that what 'characters' entails, but it complains if you include non-digits:
<img width="506" alt="Screenshot 2023-01-09 at 10 44 08 AM" src="https://user-images.githubusercontent.com/16441122/211350063-63be92e1-6370-4287-a186-1c0633b4e589.png">

