### PR TITLE
Add readymag.com to password-rules and change-password-URLs

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -100,6 +100,7 @@
     "prolific.co": "https://app.prolific.co/account/general",
     "protonmail.com": "https://mail.protonmail.com/account",
     "prowlapp.com": "https://www.prowlapp.com/settings.php",
+    "readymag.com": "https://auth.readymag.com/password/forgot",
     "reddit.com": "https://www.reddit.com/prefs/update/",
     "redirect.pizza": "https://redirect.pizza/profile",
     "reelgood.com": "https://reelgood.com/account",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -74,6 +74,9 @@
     "autify.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
+    "auth.readymag.com": {
+        "password-rules": "minlength: 8; maxlength: 128; required: lower; required: upper; allowed: special;"
+    },
     "axa.de": {
         "password-rules": "minlength: 8; maxlength: 65; required: lower; required: upper; required: digit; allowed: [-!\"§$%&/()=?;:_+*'#];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -71,11 +71,11 @@
     "astonmartinf1.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
     },
-    "autify.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
-    },
     "auth.readymag.com": {
         "password-rules": "minlength: 8; maxlength: 128; required: lower; required: upper; allowed: special;"
+    },
+    "autify.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },
     "axa.de": {
         "password-rules": "minlength: 8; maxlength: 65; required: lower; required: upper; required: digit; allowed: [-!\"§$%&/()=?;:_+*'#];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### Screenshot with password rules:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/1667907/211365190-29520a89-34b2-4d97-9558-b2def1e41c87.png">

