### PR TITLE
Updated shared credentials to include Moneybird

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -247,6 +247,16 @@
     },
     {
         "from": [
+            "moneybird.nl",
+            "moneybird.de"
+        ],
+        "to": [
+            "moneybird.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "nebula.app",
             "watchnebula.com"
         ],


### PR DESCRIPTION
A Moneybird account is created at `moneybird.nl` (or even `moneybird.de`), but the user logs in to `moneybird.com`, which prevents password managers from auto-completing the login form and frustrates the users.

The sign-up button on `moneybird.nl` ("Aanmelden", top-right corner) links to [https://www.moneybird.nl/aanmelden/](https://www.moneybird.nl/aanmelden/) and the login button next to it ("Inloggen") links to [https://www.moneybird.nl/login/](https://www.moneybird.nl/login/) that redirects to [https://moneybird.com/login/](https://moneybird.com/login/).

The sign-up button on `moneybird.de` ("Kostenlos anmelden", middle left) opens a pop-up form and the login button ("Login", top-right corner) redirects to [https://moneybird.com/login](https://moneybird.com/login).

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
