### PR TITLE
Add and Update several password change urls

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -35,6 +35,7 @@
     "blockchain.com": "https://login.blockchain.com/en/#/security-center/advanced",
     "blutdruck-shop.de": "https://www.blutdruck-shop.de/mein-passwort/",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
+    "cakeresume.com": "https://www.cakeresume.com/settings/account?ref=navs_settings",
     "callofduty.com": "https://profile.callofduty.com/cod/info",
     "carta.com": "https://app.carta.com/profiles/update/",
     "cecredentialtrust.com": "https://secure.cecredentialtrust.com/account/editpassword/",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -36,6 +36,7 @@
     "blockchain.com": "https://login.blockchain.com/en/#/security-center/advanced",
     "blutdruck-shop.de": "https://www.blutdruck-shop.de/mein-passwort/",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",
+    "bugzilla.kernel.org": "https://bugzilla.kernel.org/userprefs.cgi?tab=account",
     "cakeresume.com": "https://www.cakeresume.com/settings/account?ref=navs_settings",
     "callofduty.com": "https://profile.callofduty.com/cod/info",
     "carta.com": "https://app.carta.com/profiles/update/",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -48,6 +48,7 @@
     "columbia.com": "https://www.columbia.com/profile",
     "consumidor.gov.br": "https://www.consumidor.gov.br/pages/usuario/editar",
     "coupang.com": "https://login.coupang.com/login/userModify.pang",
+    "crackle.com": "https://www.crackle.com/profile",
     "crunchyroll.com": "https://www.crunchyroll.com/acct",
     "danawa.com": "https://auth.danawa.com/modifyMember",
     "darty.com": "https://www.darty.com/espace_client/donnees-personnelles/mot-de-passe/edition",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -11,6 +11,7 @@
     "aerlingus.com": "https://www.aerlingus.com/html/user-profile.html",
     "aesop.com": "https://www.aesop.com/my-account",
     "airbnb.com": "https://www.airbnb.com/account-settings/login-and-security",
+    "airnewzealand.com": "https://www.airnewzealand.com/membership/profile/security/password",
     "alliantcreditunion.com": "https://www.alliantcreditunion.com/OnlineBanking/Settings/AccessAndSecurity/ChangePassword.aspx",
     "allianz.com.br": "https://www.allianz.com.br/alteracao-de-password-ecliente",
     "alternate.de": "https://www.alternate.de/html/myAccount/account/basicData.html",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -32,6 +32,7 @@
     "benefitslogin.discoverybenefits.com": "https://benefitslogin.discoverybenefits.com/Profile/UpdatePassword.aspx",
     "berlet.de": "https://www.berlet.de/mein-konto.htm#my-account--edit-pass",
     "birkenstock.com": "https://www.birkenstock.com/profile",
+    "blend.io": "https://blend.io/settings",
     "blockchain.com": "https://login.blockchain.com/en/#/security-center/advanced",
     "blutdruck-shop.de": "https://www.blutdruck-shop.de/mein-passwort/",
     "browserstack.com": "https://www.browserstack.com/accounts/profile",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -12,6 +12,7 @@
     "aesop.com": "https://www.aesop.com/my-account",
     "airbnb.com": "https://www.airbnb.com/account-settings/login-and-security",
     "airnewzealand.com": "https://www.airnewzealand.com/membership/profile/security/password",
+    "alaskaair.com": "https://www.alaskaair.com/www2/ssl/myalaskaair/myalaskaair.aspx?view=myinformation&tab=email",
     "alliantcreditunion.com": "https://www.alliantcreditunion.com/OnlineBanking/Settings/AccessAndSecurity/ChangePassword.aspx",
     "allianz.com.br": "https://www.allianz.com.br/alteracao-de-password-ecliente",
     "alternate.de": "https://www.alternate.de/html/myAccount/account/basicData.html",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -53,7 +53,7 @@
     "danawa.com": "https://auth.danawa.com/modifyMember",
     "darty.com": "https://www.darty.com/espace_client/donnees-personnelles/mot-de-passe/edition",
     "daum.net": "https://member.daum.net/change/password.daum",
-    "delta.com": "https://www.delta.com/profile/basicInfo.action#editPassword",
+    "delta.com": "https://www.delta.com/myprofile/security-settings",
     "digitalocean.com": "https://cloud.digitalocean.com/settings/security",
     "discord.com": "https://discord.com/settings/account",
     "disneyplus.com": "https://www.disneyplus.com/account",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -45,6 +45,7 @@
     "clien.net": "https://www.clien.net/service/mypage/myInfoComfrim",
     "cloudflare.com": "https://dash.cloudflare.com/profile/authentication",
     "codepen.io": "https://codepen.io/settings/account",
+    "columbia.com": "https://www.columbia.com/profile",
     "consumidor.gov.br": "https://www.consumidor.gov.br/pages/usuario/editar",
     "coupang.com": "https://login.coupang.com/login/userModify.pang",
     "crunchyroll.com": "https://www.crunchyroll.com/acct",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -63,6 +63,7 @@
     "dropbox.com": "https://www.dropbox.com/account/security",
     "dwr.com": "https://www.dwr.com/profile",
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
+    "fitbit.com": "https://www.fitbit.com/settings/profile",
     "fnac.com": "https://secure.fnac.com/account/update-password",
     "foursquare.com": "https://foursquare.com/change_password",
     "geocaching.com": "https://www.geocaching.com/account/settings/changepassword",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -17,6 +17,7 @@
     "allianz.com.br": "https://www.allianz.com.br/alteracao-de-password-ecliente",
     "alternate.de": "https://www.alternate.de/html/myAccount/account/basicData.html",
     "amctheatres.com": "https://www.amctheatres.com/amcstubs/account",
+    "ana.co.jp": "https://cam.ana.co.jp/psz/us/amc_us.jsp?index=105",
     "anatel.gov.br": "https://apps.anatel.gov.br/AnatelConsumidor/ConsumidorEditar.aspx",
     "app.parkmobile.io": "https://app.parkmobile.io/account/settings",
     "arlt.com": "https://www.arlt.com/mein-passwort/",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state