### PR TITLE
Password rules for inntopia.travel

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -395,6 +395,9 @@
     "indochino.com": {
         "password-rules": "minlength: 6; maxlength: 15; required: upper; required: digit; allowed: lower, special;"
     },
+    "inntopia.travel": {
+        "password-rules": "minlength: 7; maxlength: 19; required: digit; allowed: upper,lower,[-];"
+    },
     "internationalsos.com": {
         "password-rules": "required: lower; required: upper; required: digit; required: [@#$%^&+=_];"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Unfortunately inntopia.travel doesn't publish the rules in plain text anywhere, but the rules were described as 7-19 characters with one numerical character. I manually validated that "1234567" is allowed, but I marked lower/upper/- as allowed so the generator includes them.

To access inntopia.travel, you have to use a direct URL to the page as the hostname doesn't load directly:

https://www.inntopia.travel/ecomm/shop/activities/6637250/en-US/?startdate=2023-04-30&adultcount=1&childCount=0&productsupercategoryId=22

From this page, you can buy a ski ticket to find the login form...