### PR TITLE
Remove recently-added adp.com change-password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -9,7 +9,6 @@
     "account.publishing.service.gov.uk": "https://www.account.publishing.service.gov.uk/account/edit/password",
     "acorns.com": "https://app.acorns.com/settings/change-password",
     "adobe.com": "https://account.adobe.com/security",
-    "adp.com": "https://mon.adp.com/pwdservice/changePassword",
     "adultfriendfinder.com": "https://adultfriendfinder.com/p/update.cgi?p=my_account_update_account_password",
     "ae.com": "https://www.ae.com/myaccount",
     "aerlingus.com": "https://www.aerlingus.com/html/user-profile.html",


### PR DESCRIPTION
The link is to a specific subdomain that I don't believe is representative of the entire domain.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update
