### PR TITLE
Add shared credential for JobsDB, JobStreet, SEEK

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -353,12 +353,20 @@
     {
         "from": [
             "www.seek.com.au",
-            "www.seek.co.nz"
+            "www.seek.co.nz",
+            "jobsdb.com",
+            "hk.jobsdb.com",
+            "sg.jobsdb.com",
+            "th.jobsdb.com",
+            "jobstreet.com",
+            "myjobstreet.jobstreet.co.id",
+            "myjobstreet.jobstreet.com.my",
+            "myjobstreet.jobstreet.com.ph",
+            "myjobstreet.jobstreet.com.sg"
         ],
         "to": [
             "login.seek.com"
-        ],
-        "fromDomainsAreObsoleted": true
+        ]
     },
     {
         "from": [


### PR DESCRIPTION
JobsDB and JobStreet use multiple domains for registration and login, but will be moving to using a central SEEK domain.

This will be a staged transition so `fromDomainsAreObsoleted` has been removed so it defaults to false.

Authentication is not available on the websites jobsdb.com or jobstreet.com but these are the domains used by the iOS apps. The websites use the country/language domains.

Evidence of this relationship is demonstrated by all of these sites linking to each other in their footers. Starting with https://www.seek.com.au the footer has a country dropdown (no title, is shown as 'Australia'), each country links to one of the domains listed in this change. Clicking through, the footer of each site has the same dropdown which links back to seek.com.au and the other domains.
The SSL certificates used on these sites also show the relationship between the TLD variations.
The About Us pages on each site speaks of the parent company being SEEK Limited.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

^ This will be true in the future.
