### PR TITLE
Add shared credentials by Hurricane Electric

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -154,6 +154,14 @@
     },
     {
         "shared": [
+            "dns.he.net",
+            "ipv6.he.net",
+            "math.he.net",
+            "tunnelbroker.net"
+        ]
+    },
+    {
+        "shared": [
             "ebay.at",
             "ebay.be",
             "ebay.ca",


### PR DESCRIPTION
From https://ipv6.he.net/certification/register.php:

> Registering will give you access to the following services:
>
>   * ipv6.he.net/certification
>   * tunnelbroker.net
>   * dns.he.net
>   * math.he.net
>
> If you have already registered for one of them, you may login with
> those credentials without registering again.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)