### PR TITLE
Add password rules for fccaccessonline.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -302,6 +302,9 @@
     "fc2.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },
+    "fccaccessonline.com": {
+        "password-rules": "minlength: 8; maxlength: 14; max-consecutive: 3; required: lower; required: upper; required: digit; required: [!#$%*^_];"
+    },
     "fedex.com": {
         "password-rules": "minlength: 8; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="375" alt="Screenshot 2023-03-29 at 9 35 52 AM" src="https://user-images.githubusercontent.com/6282848/228606417-7d7e4053-8954-45df-a262-a5c4398c7e3f.png">
<img width="337" alt="Screenshot 2023-03-29 at 10 12 40 AM" src="https://user-images.githubusercontent.com/6282848/228606442-7dc62942-b9d9-4def-bb3b-17862b98dc9b.png">

The login screen is available here: [https://auth.fccaccessonline.com/](https://auth.fccaccessonline.com/)

Note they seem to disallow any characters except letters and digits and the small list of special symbols (such as -).

Note they have other requirements that we can't specify but are unlikely to occur: cannot have 9+ numbers, cannot have more than 3 repeating patterns, cannot have more than 3 sequential numbers or letters. I've set max-consecutive to 3 to prevent those last two from happening.