### PR TITLE
Added shared credential for nelnet

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -273,6 +273,12 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "shared": [
+            "nelnet.com",
+            "nelnet.net"
+        ]
+    },
+    {
         "from": [
             "nordvpn.com",
             "nordpass.com"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

`nelnet.com` and `secure.nelnet.net` serve the same site, including login and account pages, and you can log into your account on either domain. Note, the bare domain `nelnet.net` redirects to `nelnet.com`. 

https://nelnet.com/welcome
https://secure.nelnet.net/welcome

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [X] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [X] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [N/A] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
