### PR TITLE
Add instructions for regenerating `websites-with-shared-credential-backends.json`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,8 @@ jobs:
       run: ruby .github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
     - name: Lint Duplicates
       run: ruby .github/workflows/lint-scripts/websites-shared-credentials-duplicates.rb
+    - name: Verify Generated Files
+      run: ruby tools/convert-shared-credential-to-legacy-format.rb --verify
 
   validate-schemas:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ Each entry in [`quirks/shared-credentials.json`](quirks/shared-credentials.json)
 
 When contributing or amending a set of websites sharing a credential backend, you should state why you believe the relevant domains do or do not share a credential backend, with evidence to support your claim. This may involve WHOIS information or content served from the domains themselves.
 
+[`quirks/websites-with-shared-credential-backends.json`](quirks/websites-with-shared-credential-backends.json) contains a lower fidelity version of the data in [`quirks/shared-credentials.json`](quirks/shared-credentials.json) and [`quirks/shared-credentials-historical.json`](quirks/shared-credentials-historical.json). It must be regenerated using [`tools/convert-shared-credential-to-legacy-format.rb`](tools/convert-shared-credential-to-legacy-format.rb) whenever those files are changed. Please do not edit [`quirks/websites-with-shared-credential-backends.json`](quirks/websites-with-shared-credential-backends.json) manually.
+
 ### Contributing a Change Password URL
 
 Use the website in question until you find the standalone page for updating the user's password, or a high-level "Account Information" or "Security" page. The closer the URL takes the user to be able to change their password, the better. Before adding a URL, ensure that it works properly both when the user is logged in and when they are not. URLs added to [`quirks/change-password-URLs.json`](quirks/change-password-URLs.json) should have a scheme of https unless the website does not allow changing the password on an https page.

--- a/tools/convert-shared-credential-to-legacy-format.rb
+++ b/tools/convert-shared-credential-to-legacy-format.rb
@@ -1,6 +1,14 @@
 #!/usr/bin/env ruby
 
 require 'json'
+require 'optparse'
+
+options = {}
+OptionParser.new do |opts|
+  opts.on("--verify", "Verify that the generated file is up-to-date.") do |v|
+    options[:verify] = v
+  end
+end.parse!
 
 tools_dir = __dir__
 root_dir = File.dirname tools_dir
@@ -37,4 +45,13 @@ addEntriesToLegacyOutputArray shared_credentials_historical_file_path, legacy_ou
 legacy_output_array = legacy_output_array.sort_by(&:first)
 
 json_to_output = JSON.pretty_generate(legacy_output_array, indent: '    ') + "\n"
-File.write output_file_path, json_to_output
+
+if options[:verify]
+  current_file_contents = File.read output_file_path
+  if current_file_contents != json_to_output
+    STDERR.puts "ERROR: #{File.basename output_file_path} is not up-to-date. Please run this script again and commit the changes."
+    exit 1
+  end
+else
+  File.write output_file_path, json_to_output
+end


### PR DESCRIPTION
[`quirks/websites-with-shared-credential-backends.json`](quirks/websites-with-shared-credential-backends.json) contains a lower fidelity version of the data in [`quirks/shared-credentials.json`](quirks/shared-credentials.json) and [`quirks/shared-credentials-historical.json`](quirks/shared-credentials-historical.json). It must be regenerated using [`tools/convert-shared-credential-to-legacy-format.rb`](tools/convert-shared-credential-to-legacy-format.rb) whenever those files are changed.

This information was not captuted in any of the current documentation, therefore CONTRIBUTING.md has been updated to include it. The workflows we run on each PR have been updated to verify that [`quirks/websites-with-shared-credential-backends.json`](quirks/websites-with-shared-credential-backends.json) is up-to-date.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update