### PR TITLE
Add password rule for wmata.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -797,6 +797,9 @@
     "wellsfargo.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"
     },
+    "wmata.com": {
+        "password-rules": "minlength: 8; required: lower, upper; required: digit; required: digit; required: [!@#$%^&*~/\"()_=+[]\\|,.?-];"
+    },
     "wsj.com": {
         "password-rules": "minlength: 5; maxlength: 15; required: digit; allowed: lower, upper, [-~!@#$^*_=`|(){}[:;\"'<>,.?]];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

From [the website's account creation page](https://smartrip.wmata.com/Account/Create), it lists the following as the password requirements:
<img width="785" alt="Screenshot 2023-05-21 at 9 56 40 AM" src="https://github.com/apple/password-manager-resources/assets/1330113/c1fd5198-e60b-4802-8f98-3b23fa11aad9">
> Your password is case-sensitive and must contain at least 8 characters, including letters, at least two numbers, and at least one of the following special characters !@#$%^&*~/"()_=+[]\|,.?-.

The main quirk I encountered that wasn't already supported was the requirement of "at least two numbers" so that has been added here.

I did attempt to use generated passwords from the Password Rules Validation Tool, but per #685 it appears to be giving back invalid examples specifically about the requirement for multiple digits so I haven't been able to completely validate things.