### PR TITLE
Remove airbnb.com from change-password quirks

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -13,7 +13,6 @@
     "ae.com": "https://www.ae.com/myaccount",
     "aerlingus.com": "https://www.aerlingus.com/html/user-profile.html",
     "aesop.com": "https://www.aesop.com/my-account",
-    "airbnb.com": "https://www.airbnb.com/account-settings/login-and-security",
     "airnewzealand.com": "https://www.airnewzealand.com/membership/profile/security/password",
     "alaskaair.com": "https://www.alaskaair.com/www2/ssl/myalaskaair/myalaskaair.aspx?view=myinformation&tab=email",
     "aliexpress.com": "https://login.aliexpress.com/",


### PR DESCRIPTION
https://www.airbnb.com/.well-known/change-password is now a valid, supported URL route to /account-settings/login-and-security.

---

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state