### PR TITLE
modified mlb.com as passwords are not allowed to have any special cha…

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -501,7 +501,7 @@
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
     },
     "mlb.com": {
-        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!\"#$%&'()*+,./:;<=>?[\\^_`{|}~]];"
+        "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "mpv.tickets.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

The website's requirements for passwords are the following:
<img width="377" alt="Screenshot 2023-06-13 at 1 30 03 PM" src="https://github.com/apple/password-manager-resources/assets/90047725/d79849a1-e044-4bfc-8721-1f5c4e06cf1d">


To determine if special characters are allowed, it was done experimentally. It enabled me to create an account with no special characters, but when testing from the password rules validation tool and adding even one of the special characters that were originally listed to be allowed — it did not enable me.

<img width="363" alt="Screenshot 2023-06-13 at 1 39 04 PM" src="https://github.com/apple/password-manager-resources/assets/90047725/f3c01c2f-4326-44ee-a854-c2f9be9f6b64">
<img width="373" alt="Screenshot 2023-06-13 at 1 38 51 PM" src="https://github.com/apple/password-manager-resources/assets/90047725/559eeffe-4f0f-4907-a855-7657eb24fbcf">

The rules have now been adjusted to note that no special characters are allowed for mlb.com.