### PR TITLE
Remove subdomain from wa.aaa.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -662,9 +662,6 @@
     "secure.snnow.ca": {
         "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper;"
     },
-    "secure.wa.aaa.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: ascii-printable;"
-    },
     "sephora.com": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },
@@ -778,6 +775,9 @@
     },
     "vivo.com.br": {
         "password-rules": "maxlength: 6; max-consecutive: 3; allowed: digit;"
+    },
+    "wa.aaa.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },
     "walkhighlands.co.uk": {
         "password-rules": "minlength: 9; maxlength: 15; required: lower; required: upper; required: digit; allowed: special;"


### PR DESCRIPTION
When creating a new account from the AAA website, a redirect from `secure.wa.aaa.com` to `identity.wa.aaa.com` happens such that the existing quirk doesn't seem to be honored. Removing the `secure` subdomain should allow the quirk to work anywhere on the site (though still under the `wa` subdomain).

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)