### PR TITLE
Add max.com to the shared credential backends list for HBO sites

### DIFF
--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -283,13 +283,6 @@
     },
     {
         "shared": [
-            "hbo.com",
-            "hbomax.com",
-            "hbonow.com"
-        ]
-    },
-    {
-        "shared": [
             "igen.fr",
             "watchgeneration.fr",
             "macg.co"

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -221,6 +221,17 @@
     },
     {
         "from": [
+            "hbo.com",
+            "hbomax.com",
+            "hbonow.com"
+        ],
+        "to": [
+            "max.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "ing.de"
         ],
         "to": [

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -383,7 +383,8 @@
     [
         "hbo.com",
         "hbomax.com",
-        "hbonow.com"
+        "hbonow.com",
+        "max.com"
     ],
     [
         "igen.fr",


### PR DESCRIPTION
Closes #701.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update