### PR TITLE
Add historical shared credential for KLM Royal Dutch Airlines

### DIFF
--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -246,6 +246,12 @@
     },
     {
         "shared": [
+            "flyingblue.com",
+            "klm.com"
+        ]
+    },
+    {
+        "shared": [
             "fidelity.com",
             "fidelityinvestments.com"
         ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -360,6 +360,10 @@
         "blade.com"
     ],
     [
+        "flyingblue.com",
+        "klm.com"
+    ],
+    [
         "fnac.com",
         "fnacspectacles.com"
     ],


### PR DESCRIPTION
`flyingblue.com` implemented their own login page in the past as `klm.com`, taking the same credential (Flying Blue number or e-mail address + Password). It now redirects to the same login page as `klm.com`.

Login page: https://login.klm.com/login/otp

This association was observed from my old password manager entries.

Whois info for `klm.com`:

```
omain Name: klm.com
Registry Domain ID: D17815627-COM
Registrar WHOIS Server: whois.eurodns.com
Registrar URL: http://www.eurodns.com
Updated Date: 2023-06-24T05:14:28Z
Creation Date: 1998-07-01T00:00:00Z
Registrar Registration Expiration Date: 2024-06-29T00:00:00Z
Registrar: Eurodns S.A.
Registrar IANA ID: 1052
Registrar Abuse Contact Email: legalservices@eurodns.com
Registrar Abuse Contact Phone: +352.27220150
Domain Status: clientTransferProhibited http://www.icann.org/epp#clientTransferProhibited
Registry Registrant ID:
Registrant Name: Manager Domain
Registrant Organization: Koninklijke Luchtvaart Maatschappij N.V.
Registrant Street: P.O. Box 7700
Registrant City: Schiphol
Registrant State/Province:
Registrant Postal Code: 1117ZL
Registrant Country: NL
Registrant Phone: +31.206486227
Registrant Fax:
Registrant Email: domains@klm.com
Registry Admin ID:
Admin Name: Manager Domain
Admin Organization: Koninklijke Luchtvaart Maatschappij N.V.
Admin Street: P.O. Box 7700
Admin City: Schiphol
Admin State/Province:
Admin Postal Code: 1117ZL
Admin Country: NL
Admin Phone: +31.206486227
Admin Fax:
Admin Email: domains@klm.com
Registry Tech ID:
Tech Name: Manager Domain
Tech Organization: Koninklijke Luchtvaart Maatschappij N.V.
Tech Street: P.O. Box 7700
Tech City: Schiphol
Tech State/Province:
Tech Postal Code: 1117ZL
Tech Country: NL
Tech Phone: +31.206486227
Tech Fax:
Tech Email: domains@klm.com
Name Server: a1-101.akam.net
Name Server: a20-65.akam.net
Name Server: a22-66.akam.net
Name Server: a3-64.akam.net
Name Server: a4-65.akam.net
Name Server: a9-67.akam.net
DNSSEC: unsigned
URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
>>> Last update of WHOIS database: 2023-07-19T06:43:13Z <<<
```

`flyingblue.com`:

```
Domain Name: flyingblue.com
Registry Domain ID: D17813205-COM
Registrar WHOIS Server: whois.eurodns.com
Registrar URL: http://www.eurodns.com
Updated Date: 2023-06-20T11:27:01Z
Creation Date: 2003-06-26T00:00:00Z
Registrar Registration Expiration Date: 2024-06-25T00:00:00Z
Registrar: Eurodns S.A.
Registrar IANA ID: 1052
Registrar Abuse Contact Email: legalservices@eurodns.com
Registrar Abuse Contact Phone: +352.27220150
Domain Status: clientTransferProhibited http://www.icann.org/epp#clientTransferProhibited
Registry Registrant ID:
Registrant Name: Manager Domain
Registrant Organization: Koninklijke Luchtvaart Maatschappij N.V.
Registrant Street: P.O. Box 7700
Registrant City: Schiphol
Registrant State/Province:
Registrant Postal Code: 1117ZL
Registrant Country: NL
Registrant Phone: +31.206486227
Registrant Fax:
Registrant Email: domains@klm.com
Registry Admin ID:
Admin Name: Manager Domain
Admin Organization: Koninklijke Luchtvaart Maatschappij N.V.
Admin Street: P.O. Box 7700
Admin City: Schiphol
Admin State/Province:
Admin Postal Code: 1117ZL
Admin Country: NL
Admin Phone: +31.206486227
Admin Fax:
Admin Email: domains@klm.com
Registry Tech ID:
Tech Name: Manager Domain
Tech Organization: Koninklijke Luchtvaart Maatschappij N.V.
Tech Street: P.O. Box 7700
Tech City: Schiphol
Tech State/Province:
Tech Postal Code: 1117ZL
Tech Country: NL
Tech Phone: +31.206486227
Tech Fax:
Tech Email: domains@klm.com
Name Server: ns.klm.nl
Name Server: ns2.kpn.net
Name Server: ns4.kpn.net
Name Server: nss.klm.nl
DNSSEC: unsigned
URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
>>> Last update of WHOIS database: 2023-07-19T06:44:28Z <<<
```

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials-historical.json
- [x] You believe that the domains were associated at some point in the past and can explain that relationship
