### PR TITLE
Add shared credential for Wellfound

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -93,6 +93,14 @@
         ]
     },
     {
+        "from": [
+            "angel.co"
+        ],
+        "to": [
+            "wellfound.com"
+        ]
+    },
+    {
         "shared": [
             "anthem.com",
             "sydneyhealth.com"

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -137,6 +137,10 @@
         "tdameritrade.com"
     ],
     [
+        "angel.co",
+        "wellfound.com"
+    ],
+    [
         "anthem.com",
         "sydneyhealth.com"
     ],


### PR DESCRIPTION
Wellfound changed their name from AngelList Talent. They updated their domain from `angel.co` to `wellfound.com` accordingly. The same e-mail+password now works on the new domain.

Proof:

* `angel.co` now directs to `wellfound.com`.
* Wellfound website header comes with "formerly AngelList Talent" under their logo.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.