### PR TITLE
Instagram & Threads.net

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -248,6 +248,12 @@
         ]
     },
     {
+        "shared": [
+            "instagram.com",
+            "threads.net"
+        ]
+    },
+    {
         "from": [
             "letsdeel.com"
         ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -404,6 +404,10 @@
         "ing.com"
     ],
     [
+        "instagram.com",
+        "threads.net"
+    ],
+    [
         "intuit.com",
         "mint.com"
     ],


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

Threads.net shown below:
![Screenshot 2023-08-25 at 13 48 29@2x](https://github.com/apple/password-manager-resources/assets/1449259/bcef4e8b-92a5-4ab7-933b-14d95b32853c)
