### PR TITLE
Remove Ring from Amazon shared credentials

### DIFF
--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -43,8 +43,7 @@
             "amazon.sa",
             "amazon.sg",
             "amazon.se",
-            "amazon.pl",
-            "ring.com"
+            "amazon.pl"
         ]
     },
     {

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -119,8 +119,7 @@
         "amazon.sa",
         "amazon.sg",
         "amazon.se",
-        "amazon.pl",
-        "ring.com"
+        "amazon.pl"
     ],
     [
         "amcrestcloud.com",


### PR DESCRIPTION
Based on some research I've done I don't see any immediate evidence of Ring ever explicitly sharing with an Amazon account. While it's possible to link the accounts for features like Alexa, sources/documentation indicate explicitly that the Ring account remains just a Ring account.

Sources:

https://blog.ring.com/about-ring/ring-now-part-amazon-family/
> Nothing! Your Ring account and the Ring App will stay the same, so you’ll continue to have a superior Ring experience.

https://support.ring.com/hc/en-us/articles/360034187232-Linking-Your-Ring-and-Amazon-Accounts

![CleanShot 2023-10-31 at 10 43 14@2x](https://github.com/apple/password-manager-resources/assets/7369280/36245c54-7da2-4029-afe9-eedfd2217d1b)

(no mention of shared credentials)

Testing with my Amazon account credentials results in a "check your username and password" error.


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update


#### for shared-credentials-historical.json
- [x] You believe that the domains were associated at some point in the past and can explain that relationship
