### PR TITLE
Add password rule and password change URL Blackwells.co.uk

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -52,6 +52,7 @@
     "bestbuy.com": "https://www.bestbuy.com/identity/accountSettings/page/password",
     "biblegateway.com": "https://www.biblegateway.com/user/account/",
     "birkenstock.com": "https://www.birkenstock.com/profile",
+    "blackwells.co.uk": "https://blackwells.co.uk/bookshop/account/personal-details",
     "blend.io": "https://blend.io/settings",
     "blockchain.com": "https://login.blockchain.com/en/#/security-center/advanced",
     "bloomberg.com": "https://www.bloomberg.com/portal/account",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -122,6 +122,9 @@
     "bitly.com": {
         "password-rules": "minlength: 6; required: lower; required: upper; required: digit; required: [`!@#$%^&*()+~{}'\";:<>?]];"
     },
+    "blackwells.co.uk": {
+        "password-rules": "minlength: 8; maxlength: 30; allowed: upper,lower,digit;"
+    },
     "bloomingdales.com": {
         "password-rules": "minlength: 7; maxlength: 16; required: lower, upper; required: digit; required: [`!@#$%^&*()+~{}'\";:<>?]];"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.) <img width="805" alt="Screenshot 2023-11-03 at 14 49 22" src="https://github.com/apple/password-manager-resources/assets/517912/d12810b5-7b37-4f3e-902d-83f8878f10e8"> <img width="809" alt="Screenshot 2023-11-03 at 14 49 30" src="https://github.com/apple/password-manager-resources/assets/517912/676e12c3-43ee-47bc-922c-78d612c0b4ed">
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

All non-alphanumeric characters are rejected, so the Safari default of adding `-`s fails with the message in the screenshot above.

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

If not logged in, then after login you are redirected to the main account dashboard rather than the password change page, but it is one click from there to the password change page rather than two from the home page.