### PR TITLE
add password rules quirk for cogmembers.org

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -179,6 +179,9 @@
     "clien.net": {
         "password-rules": "minlength: 5; required: lower, upper; required: digit;"
     },
+    "cogmembers.org": {
+        "password-rules": "minlength: 8; maxlength: 14; required: upper; required: digit, allowed: lower;"
+    },
     "collectivehealth.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="1148" alt="cogmembers org-password-rules-screenshot" src="https://github.com/apple/password-manager-resources/assets/550511/87b03941-7117-4455-adc5-e0f080e3a6e3">
