### PR TITLE
Updated password-rules.json for Garmin.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -320,6 +320,9 @@
     "fuelrewards.com": {
         "password-rules": "minlength: 8; maxlength: 16; allowed: upper,lower,digit,[!#$%@];"
     },
+    "garmin.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
+    },
     "gamestop.com": {
         "password-rules": "minlength: 8; maxlength: 225; required: lower; required: upper; required: digit; required: [!@#$%];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

---

### Screenshot
![Screenshot 2023-12-04 at 2 25 17 PM](https://github.com/apple/password-manager-resources/assets/839534/c4e927fa-3c42-4f27-ae60-1cb2071fe245)