### PR TITLE
Add shared credential backends quirks for ParkMobile, resolving #730

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -308,6 +308,15 @@
         ]
     },
     {
+        "from": [
+            "parkmobile.us"
+        ],
+        "to": [
+            "parkmobile.io"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "pinterest.com",
             "pinterest.ca",

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -532,6 +532,10 @@
         "olo.express"
     ],
     [
+        "parkmobile.us",
+        "parkmobile.io"
+    ],
+    [
         "pinterest.com",
         "pinterest.ca",
         "pinterest.co.uk",


### PR DESCRIPTION
parkmobile.us redirects to parkmobile.io.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.