### PR TITLE
Add password rule for linearity.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -461,6 +461,9 @@
     "lg.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-!#$%&'()*+,.:;=?@[^_{|}~]];"
     },
+    "linearity.io": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
+    },
     "live.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },


### PR DESCRIPTION
As per the error message on auth.linearity.io, they require a minimum length of 8, a lowercase letter, an uppercase letter, a digit, and a special character. I verified some of the special characters from the set.

<img width="407" alt="Screenshot 2023-12-16 at 22 58 56" src="https://github.com/apple/password-manager-resources/assets/3034168/2dc416b5-cc20-44bb-a56f-3e1e4a5cd7bb">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
