### PR TITLE
Update hotels.com rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -369,7 +369,7 @@
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: special;"
     },
     "hotels.com": {
-        "password-rules": "minlength: 6; maxlength: 20; required: digit; allowed: lower, upper, [@$!#()&^*%];"
+        "password-rules": "minlength: 6; maxlength: 20; required: digit; required: [-~#@$%&!*_?^]; allowed: lower, upper;"
     },
     "hotwire.com": {
         "password-rules": "minlength: 6; maxlength: 30; allowed: lower, upper, digit, [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?]];"


### PR DESCRIPTION
![image](https://github.com/apple/password-manager-resources/assets/234616/84e56780-aa29-4366-9396-6163c1f0a8e6)

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)