### PR TITLE
Add password rule for volaris.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -791,6 +791,9 @@
     "vivo.com.br": {
         "password-rules": "maxlength: 6; max-consecutive: 3; allowed: digit;"
     },
+    "volaris.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
+    },
     "wa.aaa.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="906" alt="image" src="https://github.com/apple/password-manager-resources/assets/1821230/fefd16f1-e4b9-473d-b714-f9c249d819ea">


