### PR TITLE
Add password rules quirk for milogin.michigan.gov

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -512,6 +512,9 @@
     "microsoft.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: special;"
     },
+    "milogin.michigan.gov": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@#$!~&];"
+    },
     "mintmobile.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special; allowed: [!#$%&()*+:;=@[^_`{}~]];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

This PR adds a password rules quirk for https://milogin.michigan.gov/, as shown below.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img src='https://github.com/apple/password-manager-resources/assets/31192478/3a56b932-abf1-4499-9cc7-1f43dea9e795'/>