### PR TITLE
add password rules quirk for kiehls.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -575,6 +575,9 @@
     "kfc.ca": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower; required: upper; required: digit; required: [!@#$%&?*];"
     },
+    "kiehls.com": {
+        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!#$%&?@];"
+    },
     "klm.com": {
         "password-rules": "minlength: 8; maxlength: 12;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [ ] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [ ] The top-level JSON objects are sorted alphabetically
- [ ] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ ] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [ ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [ ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)


I tested these special characters, and none of them are applicable to this website: [^*_+=`|(){}[:;"'<>], but these did work: [!#$%&?@]

Screenshot showing rules:
![kiehls](https://github.com/apple/password-manager-resources/assets/93493532/e8dd329f-9c43-4b05-ad2d-23f97123a5de)
