### PR TITLE
Add taxhawk.com shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -372,6 +372,13 @@
         ]
     },
     {
+        "shared":[
+            "taxhawk.com",
+            "freetaxusa.com",
+            "express1040.com"
+        ]
+    },
+    {
         "from": [
             "transferwise.com"
         ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -674,6 +674,11 @@
         "steamcommunity.com"
     ],
     [
+        "taxhawk.com",
+        "freetaxusa.com",
+        "express1040.com"
+    ],
+    [
         "telekom-dienste.de",
         "accounts.login.idm.telekom.com"
     ],


### PR DESCRIPTION
From TaxHawk's [LinkedIn profile](https://www.linkedin.com/company/taxhawk-inc/):

> TaxHawk, Inc. owns and operates three tax preparation websites: FreeTaxUSA.com, TaxHawk.com, and Express1040.com.

Additional supporting evidence:

- https://www.reddit.com/r/personalfinance/comments/10ebor4/comment/j4qk5nq/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button
- I personally tested and verified that I was able to log into all three websites with the same credentials.
- All three domains are [registered](https://lookup.icann.org/lookup) to TaxHawk, Inc.


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)