### PR TITLE
Add scottscheapflights.com / going.com

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -372,6 +372,15 @@
         ]
     },
     {
+        "from": [
+            "scottscheapflights.com"
+        ],
+        "to": [
+            "going.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared":[
             "taxhawk.com",
             "freetaxusa.com",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -366,12 +366,6 @@
         ]
     },
     {
-        "shared": [
-            "s.activision.com",
-            "profile.callofduty.com"
-        ]
-    },
-    {
         "from": [
             "scottscheapflights.com"
         ],
@@ -379,6 +373,12 @@
             "going.com"
         ],
         "fromDomainsAreObsoleted": true
+    },
+    {
+        "shared": [
+            "s.activision.com",
+            "profile.callofduty.com"
+        ]
     },
     {
         "shared":[


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

Evidence: scottscheapflights.com redirects to going.com **and** going.com references scottscheapflights.com