### PR TITLE
reduce max password length on costco.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -204,7 +204,7 @@
         "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit, [-.];"
     },
     "costco.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; allowed: digit, [-!#$%&'()*+/:;=?@[^_`{|}~]];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, [-!#$%&'()*+/:;=?@[^_`{|}~]];"
     },
     "coursera.com": {
         "password-rules": "minlength: 8; maxlength: 72;"


### PR DESCRIPTION
The rendered password input has `maxlength="16"`, and the "Create Account" page lists "Use between 8 and 16 characters". Decrease the maximum password length.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

### Screenshots
![image](https://github.com/apple/password-manager-resources/assets/665775/002ebdf4-6278-4c73-8e7e-3503ead52256)

![image](https://github.com/apple/password-manager-resources/assets/665775/6abc02fb-5be1-4a98-99a0-404fc93cc64e)
