### PR TITLE
Add a shared credentials relationship from nextinpact.com to next.ink

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -300,6 +300,15 @@
     },
     {
         "from": [
+            "nextinpact.com"
+        ],
+        "to": [
+            "next.ink"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "nordvpn.com",
             "nordpass.com"
         ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -508,6 +508,10 @@
         "vanityfair.com"
     ],
     [
+        "nextinpact.com",
+        "next.ink"
+    ],
+    [
         "nintendolife.com",
         "purexbox.com",
         "pushsquare.com"


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (nextinpact.com has transitioned their domain to next.ink since a few months)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.