### PR TITLE
Remove Etsy from change password quirk

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -117,7 +117,6 @@
     "ebay.com": "https://accounts.ebay.com/acctsec/security-center/chngpwd",
     "eporner.com": "https://www.eporner.com/profile/mturk_eporn/my/edit-pass/",
     "espn.com": "https://www.espn.com/",
-    "etsy.com": "https://www.etsy.com/your/account?ref=hdr_user_menu-settings",
     "eventbrite.com": "https://www.eventbrite.com/account-settings/password",
     "evite.com": "https://www.evite.com/reset_password/",
     "expedia.com": "https://www.expedia.com/user/forgotpassword",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

Hi there!

Etsy should already have the `/.well-known/change-password` resource:

```
Etsy$ curl -I --silent https://www.etsy.com/.well-known/change-password/ | head -3
HTTP/2 302
server: Apache
location: http://www.etsy.com/your/account
```

I'm not sure why Etsy was added to this list (I see it was added in 4e883c85e3c4c14ab84ef96230fd2c2ad87288d4 but the resource on Etsy existed before then). Let me know if I'm missing anything