### PR TITLE
Added password rules for ana.co.jp

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -41,6 +41,9 @@
     "americanexpress.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
     },
+    "ana.co.jp": {
+        "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
+    },
     "anatel.gov.br": {
         "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit;"
     },


### PR DESCRIPTION
Added rules that conform to the requirements from the sign up page (https://www.ana.co.jp/en/us/amc/join-amc/).

Below are screenshots from the sign up page demonstrating these requirements:

<img width="709" alt="Screenshot 2024-05-28 at 4 10 28 PM" src="https://github.com/apple/password-manager-resources/assets/88408806/01025c2a-daa9-4151-87e4-fbd8d26081a4">

<img width="617" alt="Screenshot 2024-05-29 at 4 12 23 AM" src="https://github.com/apple/password-manager-resources/assets/88408806/01a809fd-871b-442f-8875-aa75ca771617">



<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)