### PR TITLE
Added password rules for account.samsung.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -9,7 +9,7 @@
         "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: special;"
     },
     "account.samsung.com": {
-        "password-rules": "maxlength: 15; required: digit; required: special; required: upper,lower;"
+        "password-rules": "minlength: 8; maxlength: 15; required: digit; required: special; required: upper,lower;"
     },
     "admiral.com": {
         "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -8,6 +8,9 @@
     "access.service.gov.uk": {
         "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: special;"
     },
+    "account.samsung.com": {
+        "password-rules": "maxlength: 15; required: digit; required: special; required: upper,lower;"
+    },
     "admiral.com": {
         "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"
     },


### PR DESCRIPTION
Added password rules to ensure a smooth authentication experience to the Samsung (https://account.samsung.com) webpage by ensuring the generated password includes digits, special characters, and alphabets, and is no longer than 15 characters as required by the website.

Here are two screenshots of the requirements:

<img width="634" alt="Screenshot 2024-05-28 at 6 03 30 PM" src="https://github.com/apple/password-manager-resources/assets/88408806/fefa033b-a386-4091-8fc0-22195db43f98">
<img width="608" alt="Screenshot 2024-05-28 at 6 03 41 PM" src="https://github.com/apple/password-manager-resources/assets/88408806/a7912835-9ba2-4ac6-b77f-0bcb939add17">


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
