### PR TITLE
Updated password-rules.json to reflect password requirements for dodgeridge.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -260,6 +260,9 @@
     "dmm.com": {
         "password-rules": "minlength: 4; maxlength: 16; required: lower; required: upper; required: digit;"
     },
+    "dodgeridge.com": {
+        "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
+    },
     "dowjones.com": {
         "password-rules": "maxlength: 15;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

Requirements for the website (https://dodgeridge.com) are attached as an image below:
<img width="1046" alt="Screenshot 2024-05-30 at 10 54 47 AM" src="https://github.com/apple/password-manager-resources/assets/88408806/3a1cd128-01db-49fa-87d0-d06e9e4a41bd">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)