### PR TITLE
Added rules for umterps.evenue.net

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -917,6 +917,9 @@
     "udel.edu": {
         "password-rules": "minlength: 12; maxlength: 30; required: lower; required: upper; required: digit; required: [!@#$%^&*()+];"
     },
+    "umterps.evenue.net": {
+        "password-rules": "minlength: 4; maxlength: 12;"
+    },
     "user.ornl.gov": {
         "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!#$%./_];"
     },


### PR DESCRIPTION
Added rules to reflect the password length requirements on umterps.evenue.net

Here's a screenshot of the requirements from the sign up page:
<img width="380" alt="Screenshot 2024-05-30 at 11 11 05 AM" src="https://github.com/apple/password-manager-resources/assets/88408806/51a568df-d272-4972-8715-6d0f30e61f9a">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
