### PR TITLE
Add quirk for clarksoneyecare.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -176,6 +176,9 @@
     "claimlookup.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@#$%^&+=!];"
     },
+    "clarksoneyecare.com": {
+        "password-rules": "minlength: 9; required: lower; required: upper; required: digit; required: [~!@#$%^&*()_+{}|;,.<>?[]];"
+    },
     "claro.com.br": {
         "password-rules": "minlength: 8; required: lower; allowed: upper, digit, [-!@#$%&*_+=<>];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -177,7 +177,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@#$%^&+=!];"
     },
     "clarksoneyecare.com": {
-        "password-rules": "minlength: 9; required: lower; required: upper; required: digit; required: [~!@#$%^&*()_+{}|;,.<>?[]];"
+        "password-rules": "minlength: 9; allowed: lower; required: upper; required: digit; required: [~!@#$%^&*()_+{}|;,.<>?[]];"
     },
     "claro.com.br": {
         "password-rules": "minlength: 8; required: lower; allowed: upper, digit, [-!@#$%&*_+=<>];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<details>
<summary>Collapsing unrelated checklist</summary>

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
</details>

The patient portal for clarksoneyecare.com requires special characters, but of the permitted special characters, a hyphen (-) is not permitted. This results in Apple's default generated passwords not meeting the password requirements.

Here is a screenshot of the password rules:

<img width="443" alt="Screenshot 2024-05-31 at 3 18 13 PM" src="https://github.com/apple/password-manager-resources/assets/361677/6acd4b7f-36f0-41af-ae92-b37d0e29ee04">

Lowercase letters are required too, but since the website only shows you the rules on validation, I had to put something in the textbox to tell me what the requirements were, which I used a single letter "a" for that. That is why `required: lower` is included though the error message does not indicate it is required.

The website also (seemingly) has no maximum password length, so that was omitted.