### PR TITLE
Fixed failing autoformat-json-files script

### DIFF
--- a/.github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
+++ b/.github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb
@@ -3,8 +3,8 @@ require 'json'
 def process_file(file_path)
   shared_websites = JSON.parse File.read(file_path)
   shared_websites_sorted = shared_websites.sort do |a, b|
-    a_string = a["shared"] ? a["shared"].first : (a["from"] ? a["from"].first : "")
-    b_string = b["shared"] ? b["shared"].first : (b["from"] ? b["from"].first : "")
+    a_string = a["shared"] || a["from"] || [""]
+    b_string = b["shared"] || b["from"] || [""]
     a_string <=> b_string
   end
 

--- a/tools/autoformat-json-files.rb
+++ b/tools/autoformat-json-files.rb
@@ -19,6 +19,13 @@ Dir.glob('*.json').each do |file_path|
     contents_as_object = JSON.parse(original_file_contents)
     if contents_as_object.is_a? Hash
       contents_as_object = contents_as_object.sort_by { |key| key }.to_h
+    elsif contents_as_object.is_a? Array and contents_as_object[0].is_a? Hash
+      contents_as_object = contents_as_object.sort do |first, second|
+        first_content = first["shared"] || first["from"] || [""]
+        second_content = second["shared"] || second["from"] || [""]
+
+        first_content <=> second_content
+      end
     else
       contents_as_object = contents_as_object.sort
     end


### PR DESCRIPTION
The `autoformat-json-files.rb` was always failing with the error:
```
Issue parsing & reformatting 'quirks/shared-credentials-historical.json' - comparison of Hash with Hash failed
Issue parsing & reformatting 'quirks/shared-credentials.json' - comparison of Hash with Hash failed
```

This is because those JSON files contain arrays of hashes, and hashes are not comparable: https://stackoverflow.com/a/55169812/865175.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ ] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [ ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [ ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
