### PR TITLE
Add a new quirk: Apple App IDs to Domains that Share Credentials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ When contributing or amending a set of websites sharing a credential backend, yo
 
 Use the website in question until you find the standalone page for updating the user's password, or a high-level "Account Information" or "Security" page. The closer the URL takes the user to be able to change their password, the better. Before adding a URL, ensure that it works properly both when the user is logged in and when they are not. URLs added to [`quirks/change-password-URLs.json`](quirks/change-password-URLs.json) should have a scheme of https unless the website does not allow changing the password on an https page.
 
+### Contributing to Apple Application IDs to Domains that Share Credentials
+
+On macOS, for app bundle `Example.app`, you can find the App ID by dumping its entitlements with `codesign -d --entitlements - --xml path/to/Example.app`. Its App ID is the value in the XML for key `com.apple.application-identifier`. For macOS apps in particular, if there is no App ID present, the effective App ID is the app's Bundle Identifier (`CFBundleIdentifier` in the app's `Info.plist`).
+
+When contributing or amending a set of websites for an App ID, you should state why you believe the domains do share a credential backend with the app, with evidence to support your claim.
+
 ### Contributing to Websites Where 2FA Code is Appended to Password
 
 When contributing or amending a set of websites that require that the user append a generated code to their password when signing in, you should state why you believe the relevant domains require such. This may involve citing a URL to the relevant support page for the website.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ The [Contributing](CONTRIBUTING.md) document goes into detail on the format of t
 
 The file [`quirks/change-password-URLs.json`](quirks/change-password-URLs.json) contains a JSON object mapping domains to URLs where users can change their password. This is the quirks version of the [Well Known URL for Changing Passwords](https://github.com/w3c/webappsec-change-password-url). If a website adopts the Change Password URL, it should be removed from this list.
 
+### Apple App IDs to Domains that Share Credentials
+
+The file [`apple-appIDs-to-domains-shared-credentials.json`](quirks/apple-appIDs-to-domains-shared-credentials.json) expresses relationships between apps running on macOS, iOS, and iPadOS, and domains that use the same credentials. Information in this file is used by iOS and iPadOS (since version 17.4) and macOS (since version 14.4) for suggesting credentials in apps that do not have an [association with domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains). The system AutoFill capability makes use of this information to improve the user experience of signing into these apps by giving users inline suggestions of the appropriate credentials when signing in. This works for all password managers that make use of the [Credential Provider Extension](https://support.apple.com/guide/security/credential-provider-extensions-sec6319ac7b9/web) mechanism.
+
+The JSON file is a map from [App Identifier](https://developer.apple.com/help/account/manage-identifiers/register-an-app-id/) to an array of domains. Domains should be ordered by prominence from most prominent to least. The apps do not need to be distributed on Apple's App Store.
+
 ### Websites Where 2FA Code is Appended to Password
 
 The file [`quirks/websites-that-append-2fa-to-password.json`](quirks/websites-that-append-2fa-to-password.json) contains a JSON array of domains which use a two-factor authentication scheme where the user must append a generated code to their password when signing in. This list of websites could be used to prevent auto-submission of signin forms, allowing the user to append the 2FA code without frustration. It can also be used to suppress prompting to update a saved password when the submitted password is prefixed by the already-stored password.

--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -1,0 +1,66 @@
+{
+    "P7SDVXUZPK.com.etrade.mobileproiphone": [
+        "etrade.com"
+    ],
+    "PPTA7G59L3.com.kpcu.architectmobile": [
+        "kpcu.com"
+    ],
+    "KPSFBM8T3Z.com.optum.mobile.OptumBank": [
+        "myuhc.com"
+    ],
+    "KPSFBM8T3Z.com.optumhealth.mobile.OptumRX": [
+        "myuhc.com"
+    ],
+    "UF8VKHMLML.com.uhg.mobile.uhc": [
+        "myuhc.com"
+    ],
+    "LJU5B5SR84.com.educationalccu.mobile": [
+        "onlinebank.com"
+    ],
+    "T5W6CQA35T.com.fis.447iPhoneSUB": [
+        "cit.com"
+    ],
+    "L6F2ZQ2MJV.com.metlife.us.business": [
+        "access.online.metlife.com",
+        "identity.metlife.com"
+    ],
+    "QDZLSW3Z22.com.leviton.home": [
+        "leviton.com"
+    ],
+    "3976U676H6.com.allegion.sense.store": [
+        "schlage.com"
+    ],
+    "G4K4BQ7S8J.com.backblaze.BzBackupBrowser": [
+        "backblaze.com"
+    ],
+    "J983T9Z6T6.com.birdbuddy.app": [
+        "mybirdbuddy.com"
+    ],
+    "M3Q8QUH343.com.getmysa.mysa": [
+        "getmysa.com"
+    ],
+    "ZRZ3QJN79B.com.dyson.dysonlink": [
+        "dyson.com"
+    ],
+    "com.backblaze.BackblazeDownloader": [
+        "backblaze.com"
+    ],
+    "K65HQ235M5.org.sutterhealth.myhealthonline": [
+        "sutterhealth.org"
+    ],
+    "T9984LC44E.com.whisker.ios": [
+        "litter-robot.com"
+    ],
+    "K832E2UXV7.com.riotgames.mobile.leagueconnect": [
+        "riotgames.com"
+    ],
+    "GN78YB727N.com.namecheap.iosapp": [
+        "namecheap.com"
+    ],
+    "8MQ82YZW32.com.travefy.go": [
+        "travefy.com"
+    ],
+    "39FN7MD5NR.com.elation.patientpassport": [
+        "elationpassport.com"
+    ]
+}

--- a/quirks/schemas/apple-appIDs-to-domains-shared-credentials-schema.json
+++ b/quirks/schemas/apple-appIDs-to-domains-shared-credentials-schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": {
+    "type": "array",
+    "items": {
+      "type": "string"
+    }
+  }
+}

--- a/tools/autoformat-json-files.rb
+++ b/tools/autoformat-json-files.rb
@@ -14,6 +14,9 @@ error_happened = false
 Dir.glob('*.json').each do |file_path|
   relative_path = File.join("quirks", file_path)
 
+  # We don't sort this file alphabetically because there is no value in doing so.
+  next if relative_path == "quirks/apple-appIDs-to-domains-shared-credentials.json"
+
   begin
     original_file_contents = File.read(file_path)
     contents_as_object = JSON.parse(original_file_contents)


### PR DESCRIPTION
Quirk is explained in the README. Initial data is being upstreamed by Apple. Let's work together to improve Password AutoFill suggestions in apps without domain associations!

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update