### PR TITLE
feat: add shared credentials for Ting

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -428,6 +428,12 @@
         ]
     },
     {
+        "shared": [
+            "ting.com", 
+            "tingmobile.com"
+        ]
+    },
+    {
         "from": [
             "transferwise.com"
         ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -712,6 +712,10 @@
         "livenation.com"
     ],
     [
+        "ting.com",
+        "tingmobile.com"
+    ],
+    [
         "tp-link.com",
         "tplinkcloud.com"
     ],


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)

- ting.com: https://who.is/whois/ting.com
- tingmobile.com: https://who.is/whois/tingmobile.com

- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)

Issue #782 
