### PR TITLE
Aeropay embeds

### DIFF
--- a/quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json
+++ b/quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json
@@ -1,5 +1,5 @@
 [
-    "aeropay.com"
-    "aerosync.com"
+    "aeropay.com",
+    "aerosync.com",
     "plaid.com"
 ]

--- a/quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json
+++ b/quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json
@@ -1,3 +1,5 @@
 [
+    "aeropay.com"
+    "aerosync.com"
     "plaid.com"
 ]


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

Aeropay the fintech offers a service like Plaid also named Aeropay and also offers Aerosync that is limited to linking bank accounts. Both services are intended to be embedded for use within third party websites.

[Aeropay API docs](https://dev.aero.inc/docs/getting-started)
[Aerosync API docs](https://api-aerosync.readme.io/docs/welcome-to-aerosync)