### PR TITLE
yodlee-chase

### DIFF
--- a/quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json
+++ b/quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json
@@ -1,5 +1,6 @@
 [
     "aeropay.com",
     "aerosync.com",
+    "aggregation-yodlee.chase.com",
     "plaid.com"
 ]


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

Unsure whether this behavior is the same across all Yodlee embeds but Chase Bank uses Yodlee as their third-party financial institution connection provider and at least with Chase it's not on Yodlee's domain but is implemented as a subdomain of chase.com (`aggregation-yodlee.chase.com`)

<img width="1726" alt="Screenshot 2024-07-04 at 5 33 07 PM" src="https://github.com/apple/password-manager-resources/assets/47063912/48cfbcfd-fe63-4516-ae47-e84855a409e7">
