### PR TITLE
Add a password rule for pret.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -779,6 +779,9 @@
     "prestocard.ca": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit,[!\"#$%&'()*+,<>?@];"
     },
+    "pret.com": {
+        "password-rules": "minlength: 12; required: lower; required: digit; required: [@$!%*#?&]; allowed: upper;"
+    },
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },


### PR DESCRIPTION
From the website:

> Your password must…
> have 12 or more characters
> include letters a-z
> include numbers 0-9
> have at least one of these special characters @$!%*#?&

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="423" alt="Untitled" src="https://github.com/user-attachments/assets/f7e070d3-9b1e-48a2-b6d0-139ae99ef1a7">