### PR TITLE
Added shared credentials for BoardGameGeek

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -118,6 +118,14 @@
     },
     {
         "shared": [
+            "bgg.cc",
+            "boardgamegeek.com",
+            "rpggeek.com",
+            "videogamegeek.com"
+        ]
+    },
+    {
+        "shared": [
             "centralfcu.org",
             "centralfcu.com"
         ]

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -198,6 +198,12 @@
         "whistlerblackcomb.com"
     ],
     [
+        "bgg.cc",
+        "boardgamegeek.com",
+        "rpggeek.com",
+        "videogamegeek.com"
+    ],
+    [
         "boingo.com",
         "boingohotspot.com"
     ],


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

---

#### Evidence domains are currently related

##### DNS entries
- https://who.is/whois/bgg.cc
- https://who.is/dns/boardgamegeek.com
- https://who.is/dns/rpggeek.com
- https://who.is/dns/videogamegeek.com

##### SSL certificates:
```shell
echo | openssl s_client -showcerts -servername bgg.cc -connect bgg.cc:443 2>/dev/null | openssl x509 -inform pem -noout -text
echo | openssl s_client -showcerts -servername boardgamegeek.com -connect boardgamegeek.com:443 2>/dev/null | openssl x509 -inform pem -noout -text
echo | openssl s_client -showcerts -servername rpggeek.com -connect rpggeek.com:443 2>/dev/null | openssl x509 -inform pem -noout -text
echo | openssl s_client -showcerts -servername videogamegeek.com -connect videogamegeek.com:443 2>/dev/null | openssl x509 -inform pem -noout -text
```

##### Valid links between sites
<img width="255" alt="image" src="https://github.com/user-attachments/assets/5bbc48a7-2e18-4195-9d6e-5d046bca817c">
<img width="255" alt="image" src="https://github.com/user-attachments/assets/3d005180-cfd9-4b17-8a5c-8d1258e3bb7d">
<img width="255" alt="image" src="https://github.com/user-attachments/assets/975bb832-d78e-46a9-9806-5980d9f7abe2">

