### PR TITLE
Added rules for cb2.com and umterps.evenue.net

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -156,7 +156,7 @@
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
     },
     "cb2.com": {
-        "password-rules": "minlength: 7; maxlength: 18; required: lower, upper; required: digit;"
+        "password-rules": "minlength: 9; required: lower, upper; required: digit; required: [!#*_%.$];"
     },
     "ccs-grp.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower; allowed: [-!#$%&'+./=?\\^_`{|}~];"
@@ -924,7 +924,7 @@
         "password-rules": "minlength: 12; maxlength: 30; required: lower; required: upper; required: digit; required: [!@#$%^&*()+];"
     },
     "umterps.evenue.net": {
-        "password-rules": "minlength: 4; maxlength: 12;"
+        "password-rules": "minlength: 14; required: digit; required: upper; required: lower; required: [-~!@#$%^&*_+=`|(){}:;];"
     },
     "user.ornl.gov": {
         "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!#$%./_];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

This PR closes #795


Requirements for cb2.com:
![image](https://github.com/user-attachments/assets/dbef4deb-99e6-4b7e-ba43-95eaf92b57f3)



Requirements for umterps.evenue.net:
![image](https://github.com/user-attachments/assets/f8e7b74f-40ab-47b2-a9d6-554b4264ad13)



### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
