### PR TITLE
Added Telegram domains to Shared Credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -445,10 +445,13 @@
         ]
     },
     {
-        "shared": [
-            "telegram.org",
+        "from": [
             "telegram.me"
-        ]
+        ],
+        "to": [
+            "telegram.org"
+        ],
+        "fromDomainsAreObsoleted": false
     },
     {
         "shared": [

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -446,7 +446,13 @@
     },
     {
         "shared": [
-            "ting.com", 
+            "telegram.org",
+            "telegram.me"
+        ]
+    },
+    {
+        "shared": [
+            "ting.com",
             "tingmobile.com"
         ]
     },

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -710,6 +710,10 @@
         "express1040.com"
     ],
     [
+        "telegram.org",
+        "telegram.me"
+    ],
+    [
         "telekom-dienste.de",
         "accounts.login.idm.telekom.com"
     ],

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -710,8 +710,8 @@
         "express1040.com"
     ],
     [
-        "telegram.org",
-        "telegram.me"
+        "telegram.me",
+        "telegram.org"
     ],
     [
         "telekom-dienste.de",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

Telegram.me is used to autofill credentials in Telegram for iOS. Telegram.org is used for the web app (https://web.telegram.org).