### PR TITLE
Added a Change Password URL for pl.canalplus.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -238,6 +238,7 @@
     "pearson.com": "https://www.pearson.com/store/en-us/my-account/update-password",
     "pilotflyingj.com": "https://portal.pilotflyingj.com/myrewards/forgot-password",
     "pinterest.com": "https://www.pinterest.com/settings/account-settings",
+    "pl.canalplus.com": "https://logowanie.pl.canalplus.com/zmien-haslo",
     "playstation.com": "https://id.sonyentertainmentnetwork.com/id/management/#/p/security",
     "plex.tv": "https://app.plex.tv/desktop#!/account",
     "politico.com": "https://www.politico.com/settings",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state