### PR TITLE
Added a Change Password URL for Credly

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -93,6 +93,7 @@
     "crackle.com": "https://www.crackle.com/profile",
     "craigslist.org": "https://accounts.craigslist.org/pass",
     "creditkarma.com": "https://www.creditkarma.com/myprofile/security",
+    "credly.com": "https://www.credly.com/earner/settings/privacy",
     "crunchyroll.com": "https://www.crunchyroll.com/resetpw",
     "cvs.com": "https://www.cvs.com/my-account/profile/sign-in-and-security/edit-password",
     "dailymail.co.uk": "https://www.dailymail.co.uk/registration/profile/change-password.html",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state