### PR TITLE
Added a Change Password URL for Duolingo

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -112,6 +112,7 @@
     "doordash.com": "https://www.doordash.com/accounts/password/reset/",
     "dropbox.com": "https://www.dropbox.com/account/security",
     "dsw.com": "https://www.dsw.com/en/us/profile",
+    "duolingo.com": "duolingo.com/settings/profile",
     "dwr.com": "https://www.dwr.com/profile",
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "ebay.com": "https://accounts.ebay.com/acctsec/security-center/chngpwd",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -112,7 +112,7 @@
     "doordash.com": "https://www.doordash.com/accounts/password/reset/",
     "dropbox.com": "https://www.dropbox.com/account/security",
     "dsw.com": "https://www.dsw.com/en/us/profile",
-    "duolingo.com": "duolingo.com/settings/profile",
+    "duolingo.com": "https://duolingo.com/settings/profile",
     "dwr.com": "https://www.dwr.com/profile",
     "ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "ebay.com": "https://accounts.ebay.com/acctsec/security-center/chngpwd",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state