### PR TITLE
Added a Change Password URL for NextDNS

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -214,6 +214,7 @@
     "news.yahoo.com": "https://login.yahoo.com/myaccount/security/change-password/",
     "news.ycombinator.com": "https://news.ycombinator.com/changepw",
     "newsweek.com": "https://www.newsweek.com/contact",
+    "nextdns.io": "https://my.nextdns.io/account",
     "nfl.com": "https://id.nfl.com/account/change-password",
     "nhentai.net": "https://nhentai.net/reset/",
     "nike.com": "https://www.nike.com/member/settings",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state