### PR TITLE
Added a Change Password URL for Njalla

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -218,6 +218,7 @@
     "nhentai.net": "https://nhentai.net/reset/",
     "nike.com": "https://www.nike.com/member/settings",
     "nintendo.com": "https://accounts.nintendo.com/password/edit",
+    "njal.la": "https://njal.la/settings",
     "nordstrom.com": "https://www.nordstrom.com/my-account/sign-in-info",
     "nordstromrack.com": "https://www.nordstromrack.com/my-account/sign-in-info",
     "npr.org": "https://secure.npr.org/oauth2/login",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state