### PR TITLE
Updated the Change Password URL for Proton

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -247,7 +247,7 @@
     "poshmark.com": "https://poshmark.com/user/account-info",
     "ppomppu.co.kr": "https://www.ppomppu.co.kr/myinfo/profile.php",
     "prolific.co": "https://app.prolific.co/account/general",
-    "protonmail.com": "https://mail.protonmail.com/account",
+    "proton.me": "https://account.proton.me/u/0/vpn/account-password",
     "prowlapp.com": "https://www.prowlapp.com/settings.php",
     "quizlet.com": "https://quizlet.com/settings",
     "quora.com": "https://www.quora.com/settings",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

Proton has changed the domain there are using to sign in to their services.

I know that the URL says it's for Proton VPN rather than Proton Mail, but both services use shared credentials. The reason I picked a URL with VPN in the middle rather than Mail is that this URL will work regardless of what services by Proton a person uses.

It is possible to use some of the Proton services without having a Proton Mail address. In this case if you use a URL with "/mail/" rather than "/vpn/" the website prompts you to create a new Proton Mail address, instead of open the account settings.

There is also an existing, not-yet merged Pull Request by another person that reflects Proton's domain change in Shared Credentials. #521