### PR TITLE
Add Abode to change-password-URLs.json

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -202,6 +202,7 @@
     "mlb.com": "https://www.mlb.com/account/general",
     "msn.com": "https://account.live.com/password/change?refd=account.microsoft.com&fref=home.banner.changepwd",
     "music.youtube.com": "https://myaccount.google.com/signinoptions/password",
+    "my.goabode.com": "https://my.goabode.com/#/app/account",
     "myaccount.ea.com": "https://myaccount.ea.com/cp-ui/security/index",
     "myaccount.google.com": "https://myaccount.google.com/signinoptions/password",
     "myfreecams.com": "https://www.myfreecams.com/php/account.php?request=status&vcc=1674246522#change_password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### Other notes
Good news is that the password rules are quite reasonable, 10+ characters with lower, upper, numbers, and printable special characters.