### PR TITLE
Add acehardware.com to change-password-URLs.json

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -7,6 +7,7 @@
     "aarp.org": "https://secure.aarp.org/account/editaccount?request_locale=en&nu=t",
     "account.magento.com": "https://account.magento.com/customer/account/changepassword",
     "account.publishing.service.gov.uk": "https://www.account.publishing.service.gov.uk/account/edit/password",
+    "acehardware.com": "https://www.acehardware.com/myaccount#settings",
     "acorns.com": "https://app.acorns.com/settings/change-password",
     "adobe.com": "https://account.adobe.com/security",
     "adultfriendfinder.com": "https://adultfriendfinder.com/p/update.cgi?p=my_account_update_account_password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### Other notes
Nice and friendly password requirements (6+ characters, letters, numbers, special characters allowed)
