### PR TITLE
Add appID-to-domain quirks for "Balance Health" and "TD Bank (US)" apps

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -68,5 +68,12 @@
     ],
     "UPS7472725.com.metrolinx.presto.ios.consumerapp": [
         "prestocard.ca"
+    ],
+    "PX369MG78T.com.dmdbrands.balancehealth": [
+        "greatergoods.com"
+    ],
+    "498RNR3HN7.com.tdbank.iphoneapp": [
+        "td.com",
+        "tdbank.com"
     ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update