### PR TITLE
Fix required character class on unito.it password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -942,7 +942,7 @@
         "password-rules": "minlength: 14; required: digit; required: upper; required: lower; required: [-~!@#$%^&*_+=`|(){}:;];"
     },
     "unito.it": {
-        "password-rules": "minlength: 8; required: upper; required: lower; required: digit; required: [!?-+*/:;'\"{}[]()@£$%&=^#];"
+        "password-rules": "minlength: 8; required: upper; required: lower; required: digit; required: [-!?+*/:;'\"{}()@£$%&=^#[]];"
     },
     "user.ornl.gov": {
         "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!#$%./_];"


### PR DESCRIPTION
Hyphens must be the first character of the class.
Closing square brackets must be the last character of the class.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update
