### PR TITLE
Allow totp from Heroku to be suggested where it is validated

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -301,6 +301,14 @@
     },
     {
         "from": [
+            "heroku.com"
+        ],
+        "to": [
+            "verify.salesforce.com"
+        ]
+    },
+    {
+        "from": [
             "ing.de"
         ],
         "to": [

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -431,6 +431,10 @@
         "max.com"
     ],
     [
+        "heroku.com",
+        "verify.salesforce.com"
+    ],
+    [
         "igen.fr",
         "watchgeneration.fr",
         "macg.co"


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.


Hello! This is my attempt to fix https://github.com/apple/password-manager-resources/issues/695

Heroku uses `verify.salesforce.com` for TOTP validation. If I understood the file syntax correctly, this change would allow password managers to suggest TOTP from Heroku credentials when the user is on `verify.salesforce.com`. 

