### PR TITLE
Add change-password-URL for doctoralia.com.br

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -150,6 +150,7 @@
     "disneyplus.com": "https://www.disneyplus.com/account",
     "dittomusic.com": "https://dashboard.dittomusic.com/account/password",
     "dmm.co.jp": "https://accounts.dmm.co.jp/settings/change/password",
+    "doctoralia.com.br": "https://l.doctoralia.com.br/change-password",
     "docusign.net": "https://account.docusign.com/me/changepassword",
     "dominos.com": "https://www.dominos.com/en/pages/customer/#!/customer/settings/",
     "doordash.com": "https://www.doordash.com/accounts/password/reset/",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

<img width="1217" alt="Screenshot 2024-10-11 at 20 59 44" src="https://github.com/user-attachments/assets/b8123dc3-f312-4d6e-99cf-be6ab3d98117">
<img width="1217" alt="Screenshot 2024-10-11 at 20 59 51" src="https://github.com/user-attachments/assets/7acd59c7-39a7-46f1-8750-1b456a6ad44b">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state