### PR TITLE
Add change password URL for frutifica.com.br

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -187,6 +187,7 @@
     "foxbusiness.com": "https://my.foxbusiness.com/?p=account",
     "foxnews.com": "https://my.foxnews.com/?pieces=reset",
     "foxsports.com": "https://www.foxsports.com/#",
+    "frutifica.com.br": "https://www.frutifica.com.br/conta/alterar_senha",
     "gamespot.com": "https://www.gamespot.com/change-details/",
     "gap.com": "https://secure-www.gap.com/my-account/change-password",
     "genius.com": "https://genius.com/password_resets/new",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

<img width="1004" alt="Screenshot 2024-10-12 at 23 07 24" src="https://github.com/user-attachments/assets/886893f8-a29a-4f44-ae75-8aed54049d52">

<img width="1396" alt="Screenshot 2024-10-12 at 23 34 44" src="https://github.com/user-attachments/assets/c738b8e6-a9b9-4bfa-bcb5-b7ccc71a515b">

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state