### PR TITLE
Added rule for meineschufa.de

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -705,7 +705,7 @@
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
     },
     "meineschufa.de": {
-        "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: [!?#%$]; allowed: [!?#%$];"
+        "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: [!?#%$];"
     },
     "member.everbridge.net": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -704,6 +704,9 @@
     "medicare.gov": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
     },
+    "meineschufa.de": {
+        "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: [!?#%$]; allowed: [!?#%$];"
+    },
     "member.everbridge.net": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
     },


### PR DESCRIPTION
Added password rules for meineschufa.de

The website is in German but the rules, as spelled out on the website, are:

- at least 10 characters
- at least 1 digit
- at least 1 uppercase character
- at least 1 lowercase character
- at least 1 of the special characters  ! ? # % $
- no other special characters
- no spaces

<img width="1134" alt="2024-10-15_153446_Screenshot" src="https://github.com/user-attachments/assets/6ed15f71-1234-431b-8720-701414264e53">

Passwords generated by the Password Rules Validation Tool have been successfully tested.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
