### PR TITLE
Added password change for Letterboxd

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -244,6 +244,7 @@
     "leetcode.com": "https://leetcode.com/accounts/password/set/",
     "legacy.com": "https://legacy.memoriams.com/Network/Account/ChangePassword",
     "lemonde.fr": "https://moncompte.lemonde.fr/gcustomer/account/password",
+    "letterboxd.com": "https://letterboxd.com/settings/auth/",
     "linkedin.com": "https://www.linkedin.com/psettings/change-password",
     "linktr.ee": "https://linktr.ee/admin/account",
     "linode.com": "https://cloud.linode.com/profile/auth",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

