### PR TITLE
Add change password URL and app ID association for cinemark.com.br

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -75,5 +75,8 @@
     "498RNR3HN7.com.tdbank.iphoneapp": [
         "td.com",
         "tdbank.com"
+    ],
+    "U2MQ894Z4M.br.com.cinemark.iphone": [
+        "cinemark.com.br"
     ]
 }

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -110,6 +110,7 @@
     "chess.com": "https://www.chess.com/settings/password",
     "chewy.com": "https://www.chewy.com/app/resetpassword",
     "churchofjesuschrist.org": "https://account.churchofjesuschrist.org/changePassword",
+    "cinemark.com.br": "https://www.cinemark.com.br/minha-conta",
     "citi.com": "https://online.citi.com/US/ag/profile-update/change-password",
     "claro.com.br": "https://minhanet.net.com.br/webcenter/portal/MinhaNet/pages_alterarsenha",
     "clevelandclinic.org": "https://mychart.clevelandclinic.org/inside.asp?mode=passwd",


### PR DESCRIPTION
This is the official iOS app for Cinemark Brasil (https://www.cinemark.com.br). It uses the same credentials as the website, but does not include it as an associated domain.

Entitlements:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
    <dict>
        <key>application-identifier</key>
        <string>U2MQ894Z4M.br.com.cinemark.iphone</string>
        <key>aps-environment</key>
        <string>production</string>
        <key>com.apple.developer.applesignin</key>
        <array>
            <string>Default</string>
        </array>
        <key>com.apple.developer.associated-domains</key>
        <array>
            <string>applinks:cinemark.page.link</string>
        </array>
        <key>com.apple.developer.networking.wifi-info</key>
        <true/>
        <key>com.apple.developer.team-identifier</key>
        <string>U2MQ894Z4M</string>
    </dict>
</plist>
```


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

