### PR TITLE
Added rule for account.idm.telekom.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -8,6 +8,9 @@
     "access.service.gov.uk": {
         "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: special;"
     },
+    "account.idm.telekom.com": {
+        "password-rules": "minlength: 12; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
+    },
     "account.samsung.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: digit; required: special; required: upper,lower;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

Added a rule for password-change site of t-online.de as well as telekom.de – they both use the same subdomain for password-changes as well as the same password rules.

Rules have been tested using passwords generated by the password rules validation tool.

<img width="839" alt="2024-10-24_123018_Screenshot" src="https://github.com/user-attachments/assets/35d876c5-3661-412e-bbf1-ae0e20aa08b0">


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)