### PR TITLE
Add change password URL and app ID association for b2c.voegol.com.br

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -90,5 +90,8 @@
     ],
     "X9QEPGS9DR.com.questrade.fxglobal": [
         "questrade.com"
+    ],
+    "8TX3D8JQ7Q.com.yourcompany.GolCheckIn": [
+        "b2c.voegol.com.br"
     ]
 }

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -66,6 +66,7 @@
     "auction.co.kr": "https://memberssl.auction.co.kr/membership/MyInfo/MyInfo.aspx",
     "auctionzip.com": "https://www.auctionzip.com/cgi-bin/userpanel.cgi?mode=3",
     "autodesk.com": "https://accounts.autodesk.com/Profile/Security",
+    "b2c.voegol.com.br": "https://b2c.voegol.com.br/minhas-viagens/meu-perfil",
     "bamboohr.com": "https://employeewe.bamboohr.com/dashboard/password.php",
     "bancochile.cl": "https://portalpersonas.bancochile.cl/mibancochile-web/front/persona/index.html#/mi-perfil/datos-seguridad",
     "bandcamp.com": "https://bandcamp.com/settings#password",


### PR DESCRIPTION
This is the official Gol Airlines (https://www.voegol.com.br) app for iOS. A link to the app can be found at the bottom of the website.

Entitlements:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
    <dict>
        <key>application-identifier</key>
        <string>8TX3D8JQ7Q.com.yourcompany.GolCheckIn</string>
        <key>aps-environment</key>
        <string>production</string>
        <key>com.apple.developer.team-identifier</key>
        <string>8TX3D8JQ7Q</string>
    </dict>
</plist>
```

The website has a B2B channel (https://b2b.voegol.com.br/) that doesn’t seem to be supported by the app, so I’m specifically adding https://b2c.voegol.com.br, which is where the “CREATE OR ACCESS ACCOUNT” link points to. I’m applying the same logic to the change password URL; let me know if one or both cases should omit the subdomain.

<img width="1680" alt="Screenshot 2024-11-03 at 17 36 24" src="https://github.com/user-attachments/assets/93e93e6a-dc53-4c7b-a3be-0148de887124">


As for the Well-Known URLs, `voegol.com.br/.well-known/change-password` returns a 404, and `b2c.voegol.com.br/.well-known/change-password` redirects to b2c.voegol.com.br/compra.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state