### PR TITLE
Bright Horizons family app associated with correct domain

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -93,5 +93,8 @@
     ],
     "8TX3D8JQ7Q.com.yourcompany.GolCheckIn": [
         "b2c.voegol.com.br"
+    ],
+    "G9GQX52WL9.com.brighthorizons.app": [
+        "familyapp.brighthorizons.co.uk"
     ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### Evidence

The Bright Horizons family app UK (https://apps.apple.com/gb/app/bright-horizons-family/id1557887617) uses the same credentials as https://familyapp.brighthorizons.co.uk - not sure how to _prove_ this without leaking my own credentials though I'm happy to discuss further if necessary

#### Other notes

The `apple-appIDs-to-domains-shared-credentials.json` file does not seem to be sorted currently, so I've appended this record. I'm happy to sort the existing records in a separate PR (though maybe that's better done by an owner?)
