### PR TITLE
aircanada.com & aeroplan.rewardops.com share credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -72,6 +72,12 @@
     },
     {
         "shared": [
+            "aircanada.com",
+            "aeroplan.rewardops.com",
+        ]
+    },
+    {
+        "shared": [
             "airnewzealand.co.nz",
             "airnewzealand.com",
             "airnewzealand.com.au"

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -15,6 +15,12 @@
     },
     {
         "shared": [
+            "aeroplan.rewardops.com",
+            "aircanada.com"
+        ]
+    },
+    {
+        "shared": [
             "airbnb.com.ar",
             "airbnb.com.au",
             "airbnb.at",
@@ -68,12 +74,6 @@
             "airbnb.co.uk",
             "airbnb.com",
             "airbnb.co.ve"
-        ]
-    },
-    {
-        "shared": [
-            "aeroplan.rewardops.com",
-            "aircanada.com"
         ]
     },
     {

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -72,8 +72,8 @@
     },
     {
         "shared": [
-            "aircanada.com",
             "aeroplan.rewardops.com",
+            "aircanada.com"
         ]
     },
     {


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
