### PR TITLE
Add password quirk for kennedy-center.org

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -626,6 +626,9 @@
     "keldoc.com": {
         "password-rules": "minlength: 12; required: lower; required: upper; required: digit; required: [!@#$%^&*];"
     },
+    "kennedy-center.org": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@];"
+    },
     "key.harvard.edu": {
         "password-rules": "minlength: 10; maxlength: 100; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^[']];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Here is a screenshot of the Kennedy Center website with its password rules.

<img width="509" alt="Screenshot 2024-11-15 at 11 40 44 AM" src="https://github.com/user-attachments/assets/acff1226-4ba6-4177-8dc3-c35b07a3c474">

**Their explanation text is incomplete.**

The site also requires a lower-case letter, I think it is just implied. Their actual password validation regex is `^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&#])[A-Za-z\d@$!%*?&#]{8,}$`. You can see that one of the criteria is `[a-z]`.