### PR TITLE
Add password rules for carte-mobilite-inclusion.fr

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -176,6 +176,9 @@
     "carrefour.it": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
     },
+    "carte-mobilite-inclusion.fr": {
+        "password-rules": "minlength: 12; maxlength: 30; required: lower; required: upper; required: digit;"
+    },
     "cathaypacific.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: upper; required: digit; required: [!#$*^]; allowed: lower;"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

This pull request adds password rules for [`carte-mobilite-inclusion.fr`](https://www.carte-mobilite-inclusion.fr).

---
Despite officially allowing passwords with at least 12 characters and a lowercase letter, an uppercase letter and a digit, the `carte-mobilite-inclusion.fr` website does not allow symbols (such as hyphens) in account passwords:
![`passsym.png`](https://github.com/user-attachments/assets/d23775ea-1659-4115-9ec9-212afce1df3c)
(the "Forgot Password" page is used here because an account cannot be created directly on the website)

After further examination of their JavaScript source code, they seem to use the following regex to validate passwords:

```
/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])[A-Za-z0-9]{12,}$/
```

The website will also silently fail to update the password if it is longer than 30 characters:

- With a 31-character password, an HTTP 406 error occurs: ![`pass31.png`](https://github.com/user-attachments/assets/c147ae7f-4745-4e1f-9180-61b6edf4f1eb) (the token used to authenticate the request has been redacted)
- The password change request succeeds if the password has only 30 characters: ![`pass30.png`](https://github.com/user-attachments/assets/93662caf-6698-4f07-b686-54d12603aeb8)