### PR TITLE
Adding minecraft app to app shared credentials

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -99,5 +99,10 @@
     ],
     "3N57B8Z367.com.standard-life.MyPortfolio": [
         "standardlife.co.uk"
+    ],
+    "com.mojang.minecraftlauncher": [
+        "microsoft.com",
+        "live.com",
+        "xbox.com"
     ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

The Minecraft launcher app uses Microsoft services to log into the Minecraft client. If you have not logged in yet, the app will load the Microsoft Xbox log in page (which uses a Microsoft account). There are three potential domains that can be associated with Microsoft accounts that I know off the top of my head -- live.com, Microsoft.com, and xbox.com.