### PR TITLE
Add steamgames.com for shared-credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -534,7 +534,8 @@
     {
         "shared": [
             "steampowered.com",
-            "steamcommunity.com"
+            "steamcommunity.com",
+            "steamgames.com"
         ]
     },
     {


### PR DESCRIPTION

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

##### Evidence:

* https://store.steampowered.com/ footer have a "Steamworks" link, href is http://www.steampowered.com/steamworks/ but redirecting to https://partner.steamgames.com/
* SSL certificates on https://partner.steamgames.com contains https://store.steampowered.com SAN
  * <img width="837" alt="image" src="https://github.com/user-attachments/assets/7c56d903-28ae-4cac-9afe-be3ac3ec3efe" />
