### PR TITLE
Add rule for truist.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -968,6 +968,9 @@
     "treasurer.mo.gov": {
         "password-rules": "minlength: 8; maxlength: 26; required: lower; required: upper; required: digit; required: [!#$&];"
     },
+    "truist.com": {
+        "password-rules": "minlength: 8; maxlength: 28; max-consecutive: 2; required: lower; required: upper; required: digit; required: [!#$%()*,:;=@_];"
+    },
     "turkishairlines.com": {
         "password-rules": "minlength: 6; maxlength: 6; required: digit; max-consecutive: 3;"
     },


### PR DESCRIPTION
add truist.com password quirk rule

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)


<img width="450" alt="Screenshot 2025-01-04 at 5 53 31 PM" src="https://github.com/user-attachments/assets/f989bd6c-3a8d-40c4-ad07-ac317fcfab5e" />

Password rules:
8 to 28 characters with no spaces
At least 3 of these 4:
Uppercase letter
Lowercase letter
Number
Symbols allowed: ! # % ( ) * , ; : @ _ $ =
Can't repeat character more than twice in a row