### PR TITLE
Add password rules and password change page for Mountain Warehouse

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -269,6 +269,7 @@
     "michaels.com": "https://www.michaels.com/on/demandware.store/Sites-MichaelsUS-Site/default/Account-EditProfile",
     "microsoft.com": "https://account.live.com/password/Change",
     "mlb.com": "https://www.mlb.com/account/general",
+    "mountainwarehouse.com": "https://www.mountainwarehouse.com/account/details-link/",
     "msn.com": "https://account.live.com/password/change?refd=account.microsoft.com&fref=home.banner.changepwd",
     "music.youtube.com": "https://myaccount.google.com/signinoptions/password",
     "my.goabode.com": "https://my.goabode.com/#/app/account",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -729,7 +729,7 @@
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "mountainwarehouse.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-@#$%^&*_+={}|\:',?/`~();.];"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-@#$%^&*_+={}|\\:',?/`~\"();.];"
     },
     "mpv.tickets.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -728,6 +728,9 @@
     "mlb.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
+    "mountainwarehouse.com": {
+	"password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit;"
+    },
     "mpv.tickets.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -729,7 +729,7 @@
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "mountainwarehouse.com": {
-        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: [-@#$%^&*_+={}|\:',?/`~();.];"
     },
     "mpv.tickets.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -729,7 +729,7 @@
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "mountainwarehouse.com": {
-	"password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit;"
     },
     "mpv.tickets.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [X] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [X] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

The default password rules generate passwords that are rejected by mountainwarehouse.com as too long; the quirk added by this PR restricts the length such that generated passwords are accepted.

<img src="https://github.com/user-attachments/assets/55381817-804f-405e-bd9b-5e9cd314e54c" width="200" alt="screenshot" />
