### PR TITLE
Add Fortnite and Twinmotion to shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -247,6 +247,8 @@
     {
         "shared": [
             "epicgames.com",
+            "fortnite.com",
+            "twinmotion.com",
             "unrealengine.com"
         ]
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

Evidence:
- there already exists an identical case for unrealengine.com
- the websites link to each other via the menu in the top left corner
- logging in to any of the shared websites makes sso requests to the others
<img width="932" alt="Zrzut ekranu 2025-01-29 o 02 39 00" src="https://github.com/user-attachments/assets/b9f51ee2-67f3-47dd-89aa-eda0e3707213" />
