### PR TITLE
shared-credentials: Add auth.wikimedia.org to Wikimedia set

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -633,7 +633,8 @@
             "incubator.wikimedia.org",
             "outreach.wikimedia.org",
             "species.wikimedia.org",
-            "wikimania.wikimedia.org"
+            "wikimania.wikimedia.org",
+            "auth.wikimedia.org"
         ]
     },
     {


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)

Hi,

I'm an engineer on the MediaWiki Engineering team at Wikimedia Foundation. Over the next few months, we'll be moving logins from being local to each of ~900 wikis over ~10 top-level domains (with credentials shared behind the scenes) to instead happen centrally on the new `auth.wikimedia.org` domain.

This can be tested today on https://test.wikipedia.org/ where "Log in" directs you to https://auth.wikimedia.org/testwiki/wiki/Special:UserLogin. Compare this to the status quo on domains like [en.wikipedia.org](https://en.wikipedia.org/), [wikidata.org](https://www.wikidata.org/), and [ja.wikivoyage.org](https://ja.wikivoyage.org/?uselang=en) where login happens on the same domain.

Issue tracker: https://phabricator.wikimedia.org/T384844
