### PR TITLE
Add keypointcu.com as an obsolete domain for kpcu.com (#874)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -339,6 +339,15 @@
     },
     {
         "from": [
+            "keypointcu.com"
+        ],
+        "to": [
+            "kpcu.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "letsdeel.com"
         ],
         "to": [


### PR DESCRIPTION
### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [X] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [X] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
