### PR TITLE
Add password requirements for amnh.org (American Museum of Natural History)

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -53,6 +53,9 @@
     "americanexpress.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
     },
+    "amnh.org": {
+        "password-rules": "minlength: 8; required: digit; required: upper,lower"
+    },
     "ana.co.jp": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -54,7 +54,7 @@
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
     },
     "amnh.org": {
-        "password-rules": "minlength: 8; required: digit; required: upper,lower"
+        "password-rules": "minlength: 8; required: digit; required: upper,lower;"
     },
     "ana.co.jp": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -54,7 +54,7 @@
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
     },
     "amnh.org": {
-        "password-rules": "minlength: 8; required: digit; required: upper,lower;"
+        "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower; allowed: ascii-printable;"
     },
     "ana.co.jp": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

<img width="1281" alt="Screenshot 2025-03-25 at 3 54 22 PM" src="https://github.com/user-attachments/assets/7862b6f7-6438-4a11-b9b5-59144126aa67" />


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)