### PR TITLE
Add amazon.co.jp to change-password-URLs

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -27,6 +27,7 @@
     "alternate.de": "https://www.alternate.de/html/myAccount/account/basicData.html",
     "amazon.ae": "https://www.amazon.ae/ax/account/manage",
     "amazon.ca": "https://www.amazon.ca/ax/account/manage",
+    "amazon.co.jp": "https://www.amazon.co.jp/ax/account/manage",
     "amazon.co.uk": "https://www.amazon.co.uk/ax/account/manage",
     "amazon.com": "https://www.amazon.com/ax/account/manage",
     "amazon.com.au": "https://www.amazon.com.au/ax/account/manage",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -681,19 +681,6 @@
         ],
         "fromDomainsAreObsoleted": true
     },
-    
-    {
-        "from": [
-            "wikicities.com"
-            "wikia.com"
-            "wikia.org"
-        ],
-        "to": [
-            "fandom.com"
-        ],
-        "fromDomainsAreObsoleted": true
-    },
-    
     {
         "from": [
             "youneedabudget.com"

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -681,6 +681,19 @@
         ],
         "fromDomainsAreObsoleted": true
     },
+    
+    {
+        "from": [
+            "wikicities.com"
+            "wikia.com"
+            "wikia.org"
+        ],
+        "to": [
+            "fandom.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    
     {
         "from": [
             "youneedabudget.com"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state