### PR TITLE
Add GameFAQs

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -192,6 +192,7 @@
     "foxnews.com": "https://my.foxnews.com/?pieces=reset",
     "foxsports.com": "https://www.foxsports.com/#",
     "frutifica.com.br": "https://www.frutifica.com.br/conta/alterar_senha",
+    "gamefaqs.gamespot.com": "https://gamefaqs.gamespot.com/user/mailpass",
     "gamespot.com": "https://www.gamespot.com/change-details/",
     "gap.com": "https://secure-www.gap.com/my-account/change-password",
     "genius.com": "https://genius.com/password_resets/new",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -380,9 +380,6 @@
     "fuelrewards.com": {
         "password-rules": "minlength: 8; maxlength: 16; allowed: upper,lower,digit,[!#$%@];"
     },
-    "gamefaqs.gamespot.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: ascii-printable;"
-    },
     "gamestop.com": {
         "password-rules": "minlength: 8; maxlength: 225; required: lower; required: upper; required: digit; required: [!@#$%];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -380,6 +380,9 @@
     "fuelrewards.com": {
         "password-rules": "minlength: 8; maxlength: 16; allowed: upper,lower,digit,[!#$%@];"
     },
+    "gamefaqs.gamespot.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: ascii-printable;"
+    },
     "gamestop.com": {
         "password-rules": "minlength: 8; maxlength: 225; required: lower; required: upper; required: digit; required: [!@#$%];"
     },

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -302,6 +302,15 @@
         ],
         "fromDomainsAreObsoleted": true
     },
+        {
+        "from": [
+            "gamefaqs.com"
+        ],
+        "to": [
+            "gamefaqs.gamespot.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
     {
         "from": [
             "gazduire.com.ro",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
----
![IMG_7792](https://github.com/user-attachments/assets/d7c7c2d1-9e2b-4a34-afe6-f705eefcc433)
![IMG_7793](https://github.com/user-attachments/assets/374fe79f-f412-41d5-ad0d-91e4e56c9be9)
