### PR TITLE
Add AlphaTheta sites

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -689,5 +689,12 @@
             "ynab.com"
         ],
         "fromDomainsAreObsoleted": true
+    },
+    {
+        "shared": [
+            "rekordbox.com",
+            "pioneerdj.com",
+            "community.pioneerdj.com"
+        ]
     }
 ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -545,6 +545,13 @@
     },
     {
         "shared": [
+            "rekordbox.com",
+            "pioneerdj.com",
+            "community.pioneerdj.com"
+        ]
+    },
+    {
+        "shared": [
             "s.activision.com",
             "profile.callofduty.com"
         ]
@@ -689,12 +696,5 @@
             "ynab.com"
         ],
         "fromDomainsAreObsoleted": true
-    },
-    {
-        "shared": [
-            "rekordbox.com",
-            "pioneerdj.com",
-            "community.pioneerdj.com"
-        ]
     }
 ]


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [X] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [X] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)

From https://www.pioneerdj.com/en/account/login:

<img width="530" alt="image" src="https://github.com/user-attachments/assets/0de0688f-34b9-40dc-8d82-6b1a59778d37" />

https://alphatheta.com/en/company/

https://rekordbox.com/en/license-agreement/

