### PR TITLE
fix: use appropriate character class for hetzner.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -558,7 +558,7 @@
         "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower; required: upper; required: digit; required: [#$%^&!@];"
     },
     "hetzner.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit, special;"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit, required: [-^!$%/()=?+#.,;:~*@{}_&[]];"
     },
     "hilton.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

I use `gopass`, which consumes these rules for its own use, and was encountering an issue with the generated password. I went hunting for how to update the character class and wound up here.

Here's a screenshot of the allowed special characters:

![20250413T193626333](https://github.com/user-attachments/assets/69b41405-ed41-44a6-867c-0f1db5bdc716)

The Password Rules Validation Tool seems to strip out various characters from this character list. I used the tool's modified list as the value set in the rule.

---

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
