### PR TITLE
Add Zumper/PadMapper to shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -469,6 +469,13 @@
         ]
     },
     {
+        "shared": [
+            "padmapper.com",
+            "zumper.com",
+            "zumperrentals.com"
+        ]
+    },
+    {
         "from": [
             "parkmobile.us"
         ],


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

##### zumperrentals.com

Clicking log in on zumperrentals.com takes the user to zumper.com to log in:

https://github.com/user-attachments/assets/bc56d398-d940-4049-b8cb-8e6caf977841

##### zumper.com and padmapper.com

Evidence that zumper.com and padmapper.com share the same credential backend includes:

1. Attempting to create an account on padmapper.com using an email address that already has an account gives the error message, "A PadMapper/Zumper user with this email already exists"
    ![image](https://github.com/user-attachments/assets/0eab983d-fa48-42bc-be76-2018e9e8f755)
2. Signing in on either site redirects through all 3 sites, so that the user will be signed into the same account on all of them:
    <img width="1022" alt="image" src="https://github.com/user-attachments/assets/772c13e5-37bf-4970-ab44-19eb4d6ebc3c" />
