### PR TITLE
Associate the "Brvio Pass" app with brivo.com

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -116,5 +116,8 @@
     ],
     "NAN929V4UM.com.deepseek.chat": [
         "deepseek.com"
+    ],
+    "P675WD7PT4.com.brivo.pass": [
+        "brivo.com"
     ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

This app's entitlements attempt to associate it with m.brivo.com, but the served apple-app-site-association file doesn't appear to be valid. Add a quirk.