### PR TITLE
Add Schwab.com

### DIFF
--- a/quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json
+++ b/quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json
@@ -1,5 +1,6 @@
 [
     "aeropay.com",
     "aerosync.com",
-    "plaid.com"
+    "plaid.com",
+    "schwab.com"
 ]


### PR DESCRIPTION
Adding Schwab, which asks for third-party credentials in the "add a non-Schwab account" flow.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update