### PR TITLE
updated Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,138 @@
 # Password Manager Resources
 
 [![Contributor Guide](https://img.shields.io/badge/Contributor%20-Guide-2ea44f)](CONTRIBUTING.md)
-[![Slack Discussions](https://img.shields.io/badge/Join%20Slack-%23passwords-blueviolet)](mailto:password-manager-resources-maintainers@apple.com)
+[![Discuss on Slack](https://img.shields.io/badge/Slack-Discussions-blueviolet)](mailto:password-manager-resources-maintainers@apple.com)
 
-A collaborative project to improve compatibility between password managers and websites by documenting "quirks" — workarounds for site-specific behaviors.
-
----
-
-## Table of Contents
-- [Key Resources](#key-resources)
-  - [Password Rules](#password-rules)
-  - [Shared Credentials](#shared-credentials)
-  - [Change Password URLs](#change-password-urls)
-  - [2FA Code Appended to Password](#websites-where-2fa-code-is-appended-to-password)
-- [Contributing](#contributing)
-- [Discussion & Support](#asking-questions-and-discussing-ideas)
-- [Project Governance](#project-governance)
+A collaborative repository to help password managers handle website-specific quirks, improving both user experience and security.
 
 ---
 
-## Key Resources
+## 📚 Table of Contents
 
-### Password Rules
+1. [Key Resources](#key-resources)  
+   ├─ [Password Rules](#password-rules)  
+   ├─ [Shared Credentials](#shared-credentials)  
+   ├─ [Change Password URLs](#change-password-urls)  
+   └─ [2FA Code Appended to Password](#2fa-code-appended-to-password)  
+2. [Contributing](#contributing)  
+3. [Support & Discussion](#support--discussion)  
+4. [Project Governance](#project-governance)  
+
+---
+
+## 🔐 Key Resources
+
+### 📏 Password Rules
+
 **File:** [`quirks/password-rules.json`](quirks/password-rules.json)  
-**Purpose:** Generate passwords compatible with websites' requirements.  
+**Purpose:** Define site-specific password requirements to ensure successful password generation and autofill behavior.
 
-#### How It Works:
-- Domains map to [Password Rules](https://developer.apple.com/password-rules/) (e.g., `minlength: 8; required: lower, upper;`).
-- Rules apply to subdomains by default. Use `"exact-domain-match-only": true` to restrict to exact domains.  
+#### Key Notes:
 
-**Example Entry:**
+- Rules automatically apply to all subdomains.
+- Use `"exact-domain-match-only": true` to target only the main domain.
+- Syntax follows Apple’s [Password Rules specification](https://developer.apple.com/password-rules/).
+
+#### Example:
 ```json
 "example.com": {
-  "password-rules": "minlength: 12; required: upper, numeric; allowed: ascii-printable;"
+  "password-rules": "minlength: 12; required: upper, numeric; allowed: [-~];"
 },
-// example.com (2024-01-01): https://example.com/password-policy
-Shared Credentials
-Files:
+// example.com (2024-03-01): https://example.com/security/password-policy
+```
 
-Active: quirks/shared-credentials.json
+---
 
-Historical: quirks/shared-credentials-historical.json
+### 🔁 Shared Credentials
 
-Purpose:
+**Files:**
 
-Active: Suggest credentials across affiliated sites (e.g., first.website and second.website).
+- Active Sites: [`quirks/shared-credentials.json`](quirks/shared-credentials.json)  
+- Historical Sites: [`quirks/shared-credentials-historical.json`](quirks/shared-credentials-historical.json)  
 
-Historical: Suppress reuse warnings for formerly linked sites.
+**Purpose:**
 
-Change Password URLs
-File: quirks/change-password-URLs.json
-Purpose: Direct users to a site’s password change page.
+- Suggest credentials across affiliated domains (e.g., `site-a.com` and `site-b.com`).  
+- Prevent password reuse warnings for historical or legacy domain relationships.
 
-Example Entry:
+---
 
-json
-"example.com": "https://example.com/account/change-password"
-Websites Where 2FA Code is Appended to Password
-File: quirks/websites-that-append-2fa-to-password.json
-Purpose: Prevent auto-submission of forms requiring 2FA codes appended to passwords.
+### 🔑 Change Password URLs
 
-Contributing
-We welcome contributions! Please review:
+**File:** [`quirks/change-password-URLs.json`](quirks/change-password-URLs.json)  
+**Purpose:** Redirect users to the appropriate password change page for each website.
 
-Contribution Guidelines for formatting rules and examples.
+#### Example:
+```json
+"example.com": "https://example.com/account/security/password/change"
+```
 
-Verification Requirements: Ensure quirks are backed by publicly accessible evidence (e.g., a site’s help page).
+---
 
-Testing: Validate password rules with the Password Rules Parser.
+### 🔐 2FA Code Appended to Password
 
-Common Contribution Types:
+**File:** [`quirks/websites-that-append-2fa-to-password.json`](quirks/websites-that-append-2fa-to-password.json)  
+**Purpose:** Identify websites where users must manually append their 2FA code to the end of their password. This helps prevent auto-submission failures in password managers.
 
-🛠 Add/update a password rule for a domain.
+---
 
-🔗 Add a shared credential relationship.
+## ✨ Contributing
 
-🔄 Update a change password URL.
+We welcome your contributions! Here's how to get started:
 
-Asking Questions and Discussing Ideas
-GitHub Issues: Open a discussion.
+### ✅ 3-Step Contribution Process
 
-Slack: Join via email (include your GitHub username).
+1. **Review Requirements**  
+   Confirm site-specific quirks using publicly available documentation or verifiable sources.
 
-Project Maintenance
-Maintainers review PRs and ensure adherence to guidelines. To apply as a maintainer, email us with:
+2. **Follow Formatting**  
+   Adhere to the structure and rules outlined in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Your GitHub username
+3. **Test Changes**  
+   Use the [Password Rules Parser](https://github.com/apple/password-rule-parser) to validate updates.
 
-Professional affiliations (if any)
+### 🔧 Common Contribution Types
 
-Links to 5-8 contributions (PRs/issues reviewed)
+- 🆕 Add new password rules for a domain  
+- 🔄 Update or add shared credential relationships  
+- 🔗 Fix outdated or broken password change URLs  
+- 📘 Improve documentation or metadata  
 
-Project Governance
-Apple retains authority over data formats and project scope. Changes will be communicated transparently.
+---
 
+## 💬 Support & Discussion
+
+- **GitHub Issues:** Use the [Issues](../../issues) tab to raise questions, propose ideas, or start a discussion.  
+- **Slack Access:** Email maintainers to request access:
+
+```
+Subject: Slack Invite Request  
+Body: GitHub username: [your_username]
+```
+
+---
+
+## 🧭 Project Governance
+
+### 👥 Maintainers
+
+Maintainers review contributions, enforce quality standards, and support community engagement.  
+Interested in becoming a maintainer? Email the current maintainers with:
+
+- GitHub username  
+- Professional affiliations (if applicable)  
+- Links to 5–8 meaningful contributions (PRs/issues reviewed or submitted)
+
+### ⚖ Governance Model
+
+- Apple retains final authority over project scope, structure, and data formats.  
+- All significant changes are communicated transparently via GitHub Announcements.
+
+### 📜 Code of Conduct
+
+This project adheres to a strict [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a welcoming and respectful environment for all contributors.
+
+---
+
+> Thank you for contributing to a more secure and user-friendly web. 🌐🔐
+```

--- a/README.md
+++ b/README.md
@@ -1,101 +1,96 @@
 # Password Manager Resources
 
-## Welcome!
+[![Contributor Guide](https://img.shields.io/badge/Contributor%20-Guide-2ea44f)](CONTRIBUTING.md)
+[![Slack Discussions](https://img.shields.io/badge/Join%20Slack-%23passwords-blueviolet)](mailto:password-manager-resources-maintainers@apple.com)
 
-The _Password Manager Resources_ project exists so creators of password managers can collaborate on resources to make password management better for users. Resources currently consist of data, or "quirks", as well as code.
+A collaborative project to improve compatibility between password managers and websites by documenting "quirks" — workarounds for site-specific behaviors.
 
-"Quirk" is a term from web browser development that refers to a website-specific, hard-coded behavior to work around an issue with a website that can't be fixed in a principled, universal way. In this project, it has the same meaning. Although ideally, the industry will work to eliminate the need for all of the quirks in this project, there's value in customizing behaviors to ensure better user experience. The current quirks are:
+---
 
-* [**Password Rules**](#password-rules): Rules to generate compatible passwords with websites' particular requirements.
-* [**Shared Credentials**](#shared-credentials): Groups of websites known to use the same credential backend, which can be used to enhance suggested credentials to sign in to websites.
-* [**Change Password URLs**](#change-password-urls): To drive the adoption of strong passwords, it's useful to be able to take users directly to websites' change password pages.
-* [**Websites Where 2FA Code is Appended to Password**](#websites-where-2fa-code-is-appended-to-password): Some websites use a two-factor authentication scheme where the user must append a generated code to their password when signing in.
+## Table of Contents
+- [Key Resources](#key-resources)
+  - [Password Rules](#password-rules)
+  - [Shared Credentials](#shared-credentials)
+  - [Change Password URLs](#change-password-urls)
+  - [2FA Code Appended to Password](#websites-where-2fa-code-is-appended-to-password)
+- [Contributing](#contributing)
+- [Discussion & Support](#asking-questions-and-discussing-ideas)
+- [Project Governance](#project-governance)
 
-Having password managers collaborate on these resources has three high-level benefits:
+---
 
-1. By sharing resources, all password managers can improve their quality with less work than it'd take for any individual password manager to achieve the same effect.
-1. By publicly documenting website-specific behaviors, password managers can offer an incentive for websites to use standards or emerging standards to improve their compatibility with password managers; it's no fun to be called out on a list!
-1. By improving the quality of password managers, we improve user trust in them as a concept, which benefits everyone.
-
-We encourage you to incorporate the data from this project into your password manager, but kindly ask that you please contribute any quirks you have back to the project so that all users of participating password managers can benefit from your discoveries and testing.
-
-## The Resources, In Detail
+## Key Resources
 
 ### Password Rules
+**File:** [`quirks/password-rules.json`](quirks/password-rules.json)  
+**Purpose:** Generate passwords compatible with websites' requirements.  
 
-Many password managers generate strong, unique passwords for people so that they aren't tempted to create their passwords by hand, which leads to easily guessed and reused passwords. Every time a password manager generates a password that isn't compatible with a website, a person not only has a bad experience but a reason to be tempted to create their password. Compiling password rule quirks helps fewer people run into issues like these while also documenting that a service's password policy is too restrictive for people using password managers, which may incentivize the services to change.
+#### How It Works:
+- Domains map to [Password Rules](https://developer.apple.com/password-rules/) (e.g., `minlength: 8; required: lower, upper;`).
+- Rules apply to subdomains by default. Use `"exact-domain-match-only": true` to restrict to exact domains.  
 
-The file [`quirks/password-rules.json`](quirks/password-rules.json) contains a JSON object mapping domains to known good password rules for generating compatible passwords for use on that website. The [Password Rules language](https://developer.apple.com/password-rules/) is a human- and machine-readable way to concisely write and read the rules to generate a compatible password on a website. [`quirks/password-rules.json`](quirks/password-rules.json) is the quirks version of the [`passwordRules` attribute](https://github.com/whatwg/html/issues/3518), which is currently an open WHATWG proposal and supported in Safari. The same language is part of [native iOS application development API](https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules). If a website changes its password requirements to be general enough to not warrant quirks, or if it adopts the `passwordRules` attribute to accurately communicate its requirements to password managers and web browsers, it should be removed from this list.
+**Example Entry:**
+```json
+"example.com": {
+  "password-rules": "minlength: 12; required: upper, numeric; allowed: ascii-printable;"
+},
+// example.com (2024-01-01): https://example.com/password-policy
+Shared Credentials
+Files:
 
-When a domain is listed in [`quirks/password-rules.json`](quirks/password-rules.json), it means that that domain and all of its subdomains use the rule. For example, a rule for `example.com` will match URLs on `example.com` as well as `*.example.com`. A rule for `a.example.com` will match URLs on `a.example.com` as well as `*.a.example.com`, but will not match other subdomains of `example.com` such as `b.example.com`.
+Active: quirks/shared-credentials.json
 
-A rule that should only be applied to the exact domain stated as a key should have the `exact-domain-match-only` key set to a value of `true`. The absence of the `exact-domain-match-only` key means that it is false.
+Historical: quirks/shared-credentials-historical.json
 
-### Password Rules Language Parser
+Purpose:
 
-An implementation of a parser for the Password Rules language that's written in JavaScript can be found in [`tools/PasswordRulesParser.js`](tools/PasswordRulesParser.js). It can be used as a reference implementation, interpreted in build systems to convert `data/password-rules.json` to an application-specific format, or interpreted at application runtime wherever it's possible to execute JavaScript (e.g. using the JavaScriptCore framework on Apple platforms).
+Active: Suggest credentials across affiliated sites (e.g., first.website and second.website).
 
-A [third-party parser implementation](https://github.com/1Password/password-rules-parser) that's written in Rust is also available.
+Historical: Suppress reuse warnings for formerly linked sites.
 
-### Shared Credentials
+Change Password URLs
+File: quirks/change-password-URLs.json
+Purpose: Direct users to a site’s password change page.
 
-The files [`quirks/shared-credentials.json`](quirks/shared-credentials.json) and [`quirks/shared-credentials-historical.json`](quirks/shared-credentials-historical.json) express relationships between groups of websites that share credentials. The `-historical` file describes such relationships that were valid in the past but either are not valid today or we don't have a high degree of confidence are valid today.
+Example Entry:
 
-Information in [`quirks/shared-credentials.json`](quirks/shared-credentials.json) can be used by password managers to offer contextually relevant accounts to users on `first.website`, even if credentials were previously saved for `second.website`. This list should not be used as part of any user experience that releases user credentials to a website without the user's explicit review and consent. In general, saved credentials should only be suggested to users with site-bound scoping. This list is appropriate for allowing a credential saved for website A to appear on website B if the website the credential was saved for is clearly stated.
+json
+"example.com": "https://example.com/account/change-password"
+Websites Where 2FA Code is Appended to Password
+File: quirks/websites-that-append-2fa-to-password.json
+Purpose: Prevent auto-submission of forms requiring 2FA codes appended to passwords.
 
-There are existing proposals to allow different domains to declare an affiliation with each other, which could be a way for websites to solve this problem themselves, given browser and password manager adoption of such a proposal. Until and perhaps beyond then, it is useful to have these groupings of websites to make password filling suggestions more useful.
+Contributing
+We welcome contributions! Please review:
 
-Information in [`quirks/shared-credentials-historical.json`](quirks/shared-credentials-historical.json) can be used by password managers to suppress password reuse warnings across websites, given that website A and website B once were known to share credentials in the past.
+Contribution Guidelines for formatting rules and examples.
 
-The [Contributing](CONTRIBUTING.md) document goes into detail on the format of these files.
+Verification Requirements: Ensure quirks are backed by publicly accessible evidence (e.g., a site’s help page).
 
-### Change Password URLs
+Testing: Validate password rules with the Password Rules Parser.
 
-The file [`quirks/change-password-URLs.json`](quirks/change-password-URLs.json) contains a JSON object mapping domains to URLs where users can change their password. This is the quirks version of the [Well Known URL for Changing Passwords](https://github.com/w3c/webappsec-change-password-url). If a website adopts the Change Password URL, it should be removed from this list.
+Common Contribution Types:
 
-### Apple App IDs to Domains that Share Credentials
+🛠 Add/update a password rule for a domain.
 
-The file [`apple-appIDs-to-domains-shared-credentials.json`](quirks/apple-appIDs-to-domains-shared-credentials.json) expresses relationships between apps running on macOS, iOS, and iPadOS, and domains that use the same credentials. Information in this file is used by iOS and iPadOS (since version 17.4) and macOS (since version 14.4) for suggesting credentials in apps that do not have an [association with domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains). The system AutoFill capability makes use of this information to improve the user experience of signing into these apps by giving users inline suggestions of the appropriate credentials when signing in. This works for all password managers that make use of the [Credential Provider Extension](https://support.apple.com/guide/security/credential-provider-extensions-sec6319ac7b9/web) mechanism.
+🔗 Add a shared credential relationship.
 
-The JSON file is a map from [App Identifier](https://developer.apple.com/help/account/manage-identifiers/register-an-app-id/) to an array of domains. Domains should be ordered by prominence from most prominent to least. The apps do not need to be distributed on Apple's App Store.
+🔄 Update a change password URL.
 
-### Web Browser Extension Distribution Information
+Asking Questions and Discussing Ideas
+GitHub Issues: Open a discussion.
 
-The file [`web-browser-extension-distribution-information.json`](quirks/web-browser-extension-distribution-information.json) expresses relationships between web browsers and web browser extension storefronts.
+Slack: Join via email (include your GitHub username).
 
-This information may be useful to any password manager with a web browser extension for the purpose of discovering installed web browsers where a user may want to install the password manager's extension.
+Project Maintenance
+Maintainers review PRs and ensure adherence to guidelines. To apply as a maintainer, email us with:
 
-### Websites Where 2FA Code is Appended to Password
+Your GitHub username
 
-The file [`quirks/websites-that-append-2fa-to-password.json`](quirks/websites-that-append-2fa-to-password.json) contains a JSON array of domains which use a two-factor authentication scheme where the user must append a generated code to their password when signing in. This list of websites could be used to prevent auto-submission of sign-in forms, allowing the user to append the 2FA code without frustration. It can also be used to suppress prompting to update a saved password when the submitted password is prefixed by the already-stored password.
+Professional affiliations (if any)
 
-### Websites That Ask for Credentials for Other Services When Embedded as Third-party
+Links to 5-8 contributions (PRs/issues reviewed)
 
-The file [`quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json`](quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json) contains a JSON array of domains that, when embedded as a third party, are known to ask for credentials for other services. For example, some payment processors conduct transactions by being embedded in an `<iframe>` on a website. These payment processors may ask for banking credentials directly, without using OAuth.
+Project Governance
+Apple retains authority over data formats and project scope. Changes will be communicated transparently.
 
-A password manager may wish to not offer to save a new password submitted in such an `<iframe>`, because the credentials are likely to not be for the service itself.
-
-## Contributing
-
-Please review [how to contribute](CONTRIBUTING.md) if you would like to submit a pull request.
-
-## Asking Questions and Discussing Ideas
-
-If you have any questions you'd like to ask publicly, or ideas you'd like to discuss, please [raise a GitHub issue](https://github.com/apple/password-manager-resources/issues) or send a message in the project's [Slack instance](https://pw-manager-resources.slack.com). Anyone participating in the project is welcome to join the Slack instance by [emailing the project's maintainers at Apple](mailto:password-manager-resources-maintainers@apple.com) and asking for an invitation. Please include your GitHub user name when you do this.
-
-## Project Maintenance
-
-Project maintenance involves, but is not limited to, adding clarity to incoming [issues](https://github.com/apple/password-manager-resources/issues) and reviewing pull requests. Project maintainers can approve and merge pull requests. Reviewing a pull request involves judging that a proposed contribution follows the project's guidelines, as described by the [guide to contributing](CONTRIBUTING.md). If you are interested in becoming a project maintainer, please [email the project maintainers at Apple](mailto:password-manager-resources-maintainers@apple.com) with the following information:
-
-* Your name
-* Your GitHub user name
-* Any organizations you're affiliated with that are related to password management, including professionally
-* Links to examples of pull requests submitted, review feedback given, and comments on issues that demonstrate why you'd be a good project maintainer
-
-Ideally, you'd provide somewhere between five and eight examples. The purpose of this note is to remind the Apple maintainers of who you are; ideally, before sending this message, we already know you from your great contributions!
-
-Project maintainers are expected to always follow the project's [Code of Conduct](CODE_OF_CONDUCT.md), and help to model it for others.
-
-## Project Governance
-
-Although we expect this to happen very infrequently, Apple reserves the right to make changes, including changes to data format and scope, to the project at any time.


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [ ] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [ ] The top-level JSON objects are sorted alphabetically
- [ ] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [ ] The given rule isn't particularly standard and obvious for password managers
- [ ] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [ ] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [ ] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [ ] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [ ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
