### PR TITLE
Add "ungoogled-chromium" to web-browser-extension-distribution-information.json

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -411,6 +411,28 @@
             ]
         },
         {
+            "long_name": "ungoogled-chromium",
+            "short_name": "ungoogled-chromium",
+            "supported_platforms": [
+                "Mac",
+                "Windows",
+                "Linux"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "org.chromium.Chromium",
+                    "code_signing_identifier": "io.ungoogled-software.ungoogled-chromium",
+                    "code_signing_team_identifier": "B9A88FL5XJ",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Chromium/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1,
+                2,
+                4
+            ]
+        },
+        {
             "long_name": "Zen Browser",
             "short_name": "Zen",
             "supported_platforms": [


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

More info about this browser:
- https://github.com/ungoogled-software/ungoogled-chromium-macos/releases
- https://github.com/ungoogled-software/ungoogled-chromium
- Supported extension stores are based on the updater extension that is recommended by ungoogled-chromium on first install: https://github.com/NeverDecaf/chromium-web-store

I am not entirely confident that I got the bundle/code signing identifiers right, please check after me:
```
% mdls -name kMDItemCFBundleIdentifier -r Chromium.app
org.chromium.Chromium

% codesign -dvv Chromium.app
Executable=/private/tmp/Chromium.app/Contents/MacOS/Chromium
Identifier=io.ungoogled-software.ungoogled-chromium
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20500 size=1972 flags=0x12a00(kill,restrict,library-validation,runtime) hashes=50+7 location=embedded
Signature size=9039
Authority=Developer ID Application: Qian Qian (B9A88FL5XJ)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=17. 4. 2025 at 16:06:05
Notarization Ticket=stapled
Info.plist entries=37
TeamIdentifier=B9A88FL5XJ
Runtime Version=15.0.0
Sealed Resources version=2 rules=13 files=88
Internal requirements count=1 size=152
```