### PR TITLE
Add "Helium" to web-browser-extension-distribution-information.json

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -317,6 +317,26 @@
             ]
         },
         {
+            "long_name": "Helium",
+            "short_name": "Helium",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "net.imput.helium",
+                    "code_signing_identifier": "net.imput.helium",
+                    "code_signing_team_identifier": "S4Q33XPHB4",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/net.imput.helium/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1,
+                2,
+                4
+            ]
+        },
+        {
             "long_name": "Opera",
             "short_name": "Opera",
             "supported_platforms": [


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update


More info about this browser:
- https://github.com/imputnet/helium-macos/releases
- https://github.com/imputnet/helium-chromium
- Supported extension stores have the same reasoning as in #893