### PR TITLE
Add Orion RC (special version of Orion browser) to extension distribution settings

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -431,6 +431,25 @@
             ]
         },
         {
+            "long_name": "Orion Browser by Kagi Release Candidate",
+            "short_name": "Orion RC",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.kagi.kagimacOS.RC",
+                    "code_signing_identifier": "com.kagi.kagimacOS.RC",
+                    "code_signing_team_identifier": "TFVG979488",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Orion RC/Defaults/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1,
+                3
+            ]
+        },
+        {
             "long_name": "ungoogled-chromium",
             "short_name": "ungoogled-chromium",
             "supported_platforms": [


### PR DESCRIPTION
**Change:** Add "RC" version of Orion browser to Web Browser Extension Distribution Information.

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update
