### PR TITLE
Update Albertson's-related shared credentials and password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -11,6 +11,9 @@
     "account.samsung.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: digit; required: special; required: upper,lower;"
     },
+    "acmemarkets.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
+    },
     "admiral.com": {
         "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"
     },
@@ -38,6 +41,9 @@
     "ajisushionline.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [ !#$%&*?@];"
     },
+    "albertsons.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
+    },
     "alelo.com.br": {
         "password-rules": "minlength: 6; maxlength: 10; required: lower; required: upper; required: digit;"
     },
@@ -64,6 +70,9 @@
     },
     "ancestry.com": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit;"
+    },
+    "andronicos.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "angieslist.com": {
         "password-rules": "minlength: 6; maxlength: 15;"
@@ -106,6 +115,9 @@
     },
     "baidu.com": {
         "password-rules": "minlength: 6; maxlength: 14;"
+    },
+    "balduccis.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "bancochile.cl": {
         "password-rules": "minlength: 8; maxlength: 8; required: lower; required: upper; required: digit;"
@@ -181,6 +193,9 @@
     },
     "carrefour.it": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
+    },
+    "carrsqc.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "carte-mobilite-inclusion.fr": {
         "password-rules": "minlength: 12; maxlength: 30; required: lower; required: upper; required: digit;"
@@ -410,6 +425,9 @@
     "gwl.greatwestlife.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [-!#$%_=+<>];"
     },
+    "haggen.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
+    },
     "hangseng.com": {
         "password-rules": "minlength: 8; maxlength: 30; required: lower; required: upper; required: digit;"
     },
@@ -629,6 +647,9 @@
     "japanpost.jp": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
     },
+    "jewelosco.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
+    },
     "jordancu-onlinebanking.org": {
         "password-rules": "minlength: 6; maxlength: 32; allowed: upper, lower, digit,[-!\"#$%&'()*+,.:;<=>?@[^_`{|}~]];"
     },
@@ -646,6 +667,9 @@
     },
     "kiehls.com": {
         "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!#$%&?@];"
+    },
+    "kingsfoodmarkets.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "klm.com": {
         "password-rules": "minlength: 8; maxlength: 12;"
@@ -797,6 +821,9 @@
     "packageconciergeadmin.com": {
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },
+    "pavilions.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
+    },
     "paypal.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower, upper; required: digit, [!@#$%^&*()];"
     },
@@ -859,6 +886,9 @@
     },
     "questdiagnostics.com": {
         "password-rules": "minlength: 8; maxlength: 30; required: upper, lower; required: digit, [!#$%&()*+<>?@^_~];"
+    },
+    "randalls.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "rejsekort.dk": {
         "password-rules": "minlength: 7; maxlength: 15; required: lower; required: upper; required: digit;"
@@ -923,6 +953,9 @@
     "sfwater.org": {
         "password-rules": "minlength: 10; maxlength: 30; required: digit; allowed: lower, upper, [!@#$%*()_+^}{:;?.];"
     },
+    "shaws.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
+    },
     "signin.ea.com": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
@@ -940,6 +973,9 @@
     },
     "ssa.gov": {
         "password-rules": "required: lower; required: upper; required: digit; required: [~!@#$%^&*];"
+    },
+    "starmarket.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "store.nintendo.co.uk": {
         "password-rules": "minlength: 8; maxlength: 20;"
@@ -979,6 +1015,9 @@
     },
     "tix.soundrink.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
+    },
+    "tomthumb.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "training.confluent.io": {
         "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%*@^_~];"
@@ -1048,6 +1087,9 @@
     },
     "volaris.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
+    },
+    "vons.com": {
+        "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "wa.aaa.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: ascii-printable;"

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -79,10 +79,14 @@
     },
     {
         "shared": [
-            "albertsons.com",
             "acmemarkets.com",
+            "albertsons.com",
+            "andronicos.com",
+            "balduccis.com",
             "carrsqc.com",
+            "haggen.com",
             "jewelosco.com",
+            "kingsfoodmarkets.com",
             "pavilions.com",
             "randalls.com",
             "safeway.com",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -15,6 +15,25 @@
     },
     {
         "shared": [
+            "acmemarkets.com",
+            "albertsons.com",
+            "andronicos.com",
+            "balduccis.com",
+            "carrsqc.com",
+            "haggen.com",
+            "jewelosco.com",
+            "kingsfoodmarkets.com",
+            "pavilions.com",
+            "randalls.com",
+            "safeway.com",
+            "shaws.com",
+            "starmarket.com",
+            "tomthumb.com",
+            "vons.com"
+        ]
+    },
+    {
+        "shared": [
             "airbnb.com.ar",
             "airbnb.com.au",
             "airbnb.at",
@@ -75,25 +94,6 @@
             "airnewzealand.co.nz",
             "airnewzealand.com",
             "airnewzealand.com.au"
-        ]
-    },
-    {
-        "shared": [
-            "acmemarkets.com",
-            "albertsons.com",
-            "andronicos.com",
-            "balduccis.com",
-            "carrsqc.com",
-            "haggen.com",
-            "jewelosco.com",
-            "kingsfoodmarkets.com",
-            "pavilions.com",
-            "randalls.com",
-            "safeway.com",
-            "shaws.com",
-            "starmarket.com",
-            "tomthumb.com",
-            "vons.com"
         ]
     },
     {


### PR DESCRIPTION
The following sites have been confirmed to share a password backend with safeway.com:
* andronicos.com
* balduccis.com
* haggen.com
* kingsfoodmarkets.com

See also #899 and evidence these companies are related at https://www.albertsonscompanies.com/about-aci/overview/default.aspx. These sites accept login credentials on their own domain, not a redirect to another domain on the `shared` list.

Additionally, I tested these sites password reset flows matched the password rules for safeway.com:
* acmemarkets.com
* andronicos.com

And I mirrored the safeway.com password rules to all the sites shared with safeway.com. Note that I tested the password rules only for safeway.com, acmemarkets.com, and andronicos.com, and extrapolated to all the sites with the shared backend.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
