### PR TITLE
Add shared credentials for United Supermarkets websites

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -94,6 +94,14 @@
     },
     {
         "shared": [
+            "albertsonsmarket.com",
+            "amigosunited.com",
+            "marketstreetunited.com",
+            "unitedsupermarkets.com"
+        ]
+    },
+    {
+        "shared": [
             "alelo.com.br",
             "meualelo.com.br"
         ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -98,21 +98,6 @@
     },
     {
         "shared": [
-            "albertsons.com",
-            "acmemarkets.com",
-            "carrsqc.com",
-            "jewelosco.com",
-            "pavilions.com",
-            "randalls.com",
-            "safeway.com",
-            "shaws.com",
-            "starmarket.com",
-            "tomthumb.com",
-            "vons.com"
-        ]
-    },
-    {
-        "shared": [
             "albertsonsmarket.com",
             "amigosunited.com",
             "marketstreetunited.com",


### PR DESCRIPTION
The following sites share a password backend:
* albertsonsmarket.com
* amigosunited.com
* marketstreetunited.com
* unitedsupermarkets.com

I verified this by creating an account with albertsonsmarket.com and successfully logging in with those credentials at each of the other sites. They accept the credentials on each domain, and not a centralized domain. These sites also have a documented business connection at https://theunitedfamily.com.

There were no password rules warranting an entry in quirks/password-rules.json.

United Express does not have its own domain.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
