### PR TITLE
Add password rules for savemart.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -899,6 +899,9 @@
     "santander.de": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit; allowed: [-!#$%&'()*,.:;=?^{}];"
     },
+    "savemart.com": {
+        "password-rules": "minlength: 8; maxlength: 12; required: digit; required: upper,lower; required: [!#$%&@]; allowed: ascii-printable;"
+    },
     "sbisec.co.jp": {
         "password-rules": "minlength: 10; maxlength: 20; allowed: upper,lower,digit;"
     },


### PR DESCRIPTION
The declared password rules for savemart.com are:

> Password must be between 8 and 12 characters and must contain at least 1 character from each of the following:
> * Letters (a–z) (A–Z)
> * Numbers (0–9)
> * Special characters (@, #, $, !, %, &, etc.)

This isn't the whole story though; actually, a special character from their provided list (before "etc.") are _required_, and other special characters are _allowed_.

I verified some edge cases (no lower, no upper, special chars at the front) as well as ~30 generated passwords matching the supplied rule from https://developer.apple.com/password-rules.

Screenshot for reference:

<img width="1436" alt="Screenshot of bridgeidp.savemart.com from 2025-05-05 at 5:11:00 PM" src="https://github.com/user-attachments/assets/b80b3c08-ad6b-48a0-b1e5-0f6dcedce016" />

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
