### PR TITLE
Update shared-credentials.json: Fandom.com

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -671,6 +671,7 @@
     },
         {
         "from": [
+            "gamepedia.com",
             "wikia.com",
             "wikia.org",
             "wikicities.com"

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -323,7 +323,7 @@
         ],
         "fromDomainsAreObsoleted": true
     },
-            {
+    {
         "from": [
             "gamepedia.com",
             "wikia.com",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -323,6 +323,18 @@
         ],
         "fromDomainsAreObsoleted": true
     },
+            {
+        "from": [
+            "gamepedia.com",
+            "wikia.com",
+            "wikia.org",
+            "wikicities.com"
+        ],
+        "to": [
+            "fandom.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
     {
         "from": [
             "gazduire.com.ro",
@@ -666,18 +678,6 @@
         ],
         "to": [
             "wacom.com"
-        ],
-        "fromDomainsAreObsoleted": true
-    },
-        {
-        "from": [
-            "gamepedia.com",
-            "wikia.com",
-            "wikia.org",
-            "wikicities.com"
-        ],
-        "to": [
-            "fandom.com"
         ],
         "fromDomainsAreObsoleted": true
     },

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -669,6 +669,17 @@
         ],
         "fromDomainsAreObsoleted": true
     },
+        {
+        "from": [
+            "wikia.com",
+            "wikia.org",
+            "wikicities.com"
+        ],
+        "to": [
+            "fandom.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
     {
         "shared": [
             "wikipedia.org",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.
