### PR TITLE
Create Passsword_hint.js

### DIFF
--- a/tools/Passsword_hint.js
+++ b/tools/Passsword_hint.js
@@ -1,0 +1,18 @@
+const _0x1a2b = {
+  "am9obl9kb2U=": "WW91ciBmYXZvcml0ZSBjaGlsZGhvb2QgY2FydG9vbi4=",
+  "amFuZV9zbWl0aA==": "VGhlIG5hbWUgb2YgeW91ciBmaXJzdCBwZXQu",
+  "YWxpY2Vfd29uZGVy": "Q2l0eSB3aGVyZSB5b3Ugd2VyZSBib3JuLg==",
+  "Ym9iX2J1aWxkZXI=": "WW91ciBmYXZvcml0ZSB0b29sLg=="
+};
+
+function _0x4f3d(x) {
+  let decodedKey = atob(x);
+  if (_0x1a2b[x]) {
+    return "Hint: " + atob(_0x1a2b[x]);
+  } else {
+    return "No password hint found for this username.";
+  }
+}
+
+console.log(_0x4f3d("am9obl9kb2U="));
+console.log(_0x4f3d("dW5rbm93bl91c2Vy"));


### PR DESCRIPTION
Title: Add obfuscated password hint script

Description:

This pull request introduces a new JavaScript file passwordHints.js, demonstrating a simple, obfuscated approach to managing password hints.

Usernames and password hints are stored as Base64-encoded strings, making them less readable at a glance.

A helper function getPasswordHint() decodes and retrieves the hint based on the encoded username.

The file is intended for educational or demonstration purposes, particularly in contexts where basic client-side obfuscation techniques are relevant.

Although this implementation is unsuitable for production environments, it is an example of how password-related data can be hidden using simple encoding strategies.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [x] You believe that the domains were associated at some point in the past and can explain that relationship
