### PR TITLE
password-rules for act.org

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -14,6 +14,9 @@
     "acmemarkets.com": {
         "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
+    "act.org": {
+        "password-rules": "minlength: 8; maxlength: 64; required: lower; required: upper; required: digit; required: [!#$%&*@^];"
+    },
     "admiral.com": {
         "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"
     },


### PR DESCRIPTION
act.org prohibits hyphens and requires one of each character class. The symbols list is derived from their user-facing password guidance (see attached screenshots).

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

![IMG_0240](https://github.com/user-attachments/assets/07d5946a-4e7e-4fce-8c37-c9f8cc90bc17)
![IMG_0241](https://github.com/user-attachments/assets/bcb7cae9-a0bf-450e-af8d-1c0032bc5f5a)
![IMG_0242](https://github.com/user-attachments/assets/3b00902b-2f64-4d7f-9bc7-397dd6b29080)
