### PR TITLE
Add change password URL for lu.ma

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -258,6 +258,7 @@
     "livejasmin.com": "https://www.livejasmin.com/en/girls/#!settings/account",
     "login.gov": "https://secure.login.gov/manage/password",
     "lowes.com": "https://www.lowes.com/mylowes/profile",
+    "lu.ma": "https://lu.ma/settings",
     "macys.com": "https://www.macys.com/account/profile?cm_sp=macys_account-_-my_account-_-my_profile&linklocation=leftrail",
     "marketwatch.com": "https://customercenter.marketwatch.com/account#password?mod=ql",
     "marktplaats.nl": "https://www.marktplaats.nl/account/password-reset/confirm.html",


### PR DESCRIPTION
The "well-known URL" (https://lu.ma/.well-known/change-password) does exist, but points to a calendar:

<img width="921" alt="Screenshot 2025-06-17 at 00 14 22" src="https://github.com/user-attachments/assets/93417cbe-20f0-44cc-9302-8d2fc7c9a296" />

<br>From what I could gather, /.well-known (yes, with the dot 🙂) is the URL for the calendar, and the rest is ignored:

<img width="614" alt="Screenshot 2025-06-17 at 00 08 31" src="https://github.com/user-attachments/assets/cc870fcb-cc8d-4bde-b573-3a717208d2ad" />
<img width="615" alt="Screenshot 2025-06-17 at 00 08 45" src="https://github.com/user-attachments/assets/90bee050-ebc6-46c4-ac8e-4383e758618f" />

<br>The option for changing the password is inside the settings page:

<img width="921" alt="Screenshot 2025-06-17 at 00 15 09" src="https://github.com/user-attachments/assets/6f4bb243-0c2b-46af-bb5e-b959bc596151" />

<br>On signed-out access, the user is correctly redirected (via https://lu.ma/signin?next=%2Fsettings).

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
