### PR TITLE
added Kobold Press sites as shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -389,10 +389,8 @@
         "fromDomainsAreObsoleted": true
     },
     {
-        "from": [
-            "koboldpress.com"
-        ],
-        "to": [
+        "shared": [
+            "koboldpress.com",
             "labyrinth.talesofthevaliant.com"
         ]
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

- added Kobold Press sites as shared credentials

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.) - [noted in Labyrinth login portal as a shared credential with Kobold Press Webstore](https://labyrinth.talesofthevaliant.com/login/) and directly confirmed by logging in with my own account credentials to both portals
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in. - n/a