### PR TITLE
Add a password rule for app8menu.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -92,6 +92,9 @@
     "app.parkmobile.io": {
         "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!@#$%^&];"
     },
+    "app8menu.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@$!%*?&];"
+    },
     "apple.com": {
         "password-rules": "minlength: 8; maxlength: 63; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },


### PR DESCRIPTION
Requirements:
- at least 8 characters
- one upper
- one lower
- one number
- one special character

And without any special characters, they say: “The password requires at least 1 symbol (@$!%*?&)”

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)