### PR TITLE
Add a password rule for publix.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -887,6 +887,9 @@
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },
+    "publix.com": {
+        "password-rules": "minlength: 8; maxlength: 28; required: upper; required: lower; allowed: digit,[!#$%*@^];"
+    },
     "qdosstatusreview.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&@^];"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

--- 
For Publix.com (or changing a password on account.publix.com) standard rules such as the Passwords app's default generated passwords usually have a mix of lowercase, uppercase, and a digit, so they work fine: <img width="959" height="654" alt="Screenshot 2025-07-22 at 6 01 12 PM" src="https://github.com/user-attachments/assets/29ffe858-0bed-43df-83c8-55034bfce6c7" />

But when trying to sign up on rx.publix.com, the only special characters allowed are ones that would satisfy the "special character" requirement: <img width="774" height="593" alt="Screenshot 2025-07-22 at 6 00 31 PM" src="https://github.com/user-attachments/assets/877db7aa-ce52-4a1a-92ee-4b8e7f0129ff" />

In particular, the hyphen of Passwords's generated passwords is not allowed. Non-rx websites _do_ allow hyphens, but those won't satisfy the requirement of having a special character. 

I made rules and tested their outputs using the Validation Tool for both cases, confirming that the subset allowed on rx.publix.com works on the others too. It may be more appropriate to scope this change under the subdomain only, but since strong passwords are possible with this set of rules, the change here uses the root domain for now. 