### PR TITLE
Update change-password-URLs.json to include singapore air

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -374,7 +374,7 @@
     "shoop.de": "https://www.shoop.de/einstellungen/benutzerdaten",
     "shopback.co.kr": "https://www.shopback.co.kr/account/change-password",
     "shutterfly.com": "https://www.shutterfly.com/account-settings/",
-    "singaporeair.com": "https://www.singaporeair.com/kfResetPIN-flow.form",
+    "singaporeair.com": "https://www.singaporeair.com/krisflyer/profile/security",
     "sipgatebasic.de": "https://app.sipgatebasic.de/settings",
     "slickdeals.net": "https://slickdeals.net/forums/login.php?do=lostpw",
     "soap2day.to": "https://soap2day.to/home/user/changepassword",


### PR DESCRIPTION
Added singapore airlines change password url

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
