### PR TITLE
Add a password rule for yeti.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1154,6 +1154,9 @@
     "yatra.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
     },
+    "yeti.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [#$%*];"
+    },
     "zara.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
     },


### PR DESCRIPTION
Their rules are stated as:
8+ characters
1 lowercase and 1 UPPERCASE letter
1 number and 1 special character (*#$%)

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)