### PR TITLE
Add "Opera Neon Developer" browser; speculatively add "Opera Neon" br…

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -443,7 +443,7 @@
                     "bundle_identifier": "com.operasoftware.OperaAir",
                     "code_signing_identifier": "com.operasoftware.OperaAir",
                     "code_signing_team_identifier": "A2P9LX4JPN",
-                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.operasoftware.OperaAir/Extensions"
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.operasoftware.OperaAir/Default/Extensions"
                 }
             },
             "supported_store_identifiers": [
@@ -463,7 +463,7 @@
                     "bundle_identifier": "com.operasoftware.OperaNext",
                     "code_signing_identifier": "com.operasoftware.OperaNext",
                     "code_signing_team_identifier": "A2P9LX4JPN",
-                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.operasoftware.OperaNext/Extensions"
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.operasoftware.OperaNext/Default/Extensions"
                 }
             },
             "supported_store_identifiers": [
@@ -483,7 +483,47 @@
                     "bundle_identifier": "com.operasoftware.OperaDeveloper",
                     "code_signing_identifier": "com.operasoftware.OperaDeveloper",
                     "code_signing_team_identifier": "A2P9LX4JPN",
-                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.operasoftware.OperaDeveloper/Extensions"
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.operasoftware.OperaDeveloper/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                4,
+                1
+            ]
+        },
+        {
+            "long_name": "Opera Neon",
+            "short_name": "Opera Neon",
+            "supported_platforms": [
+                "Mac",
+                "Windows"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.operasoftware.OperaNeon",
+                    "code_signing_identifier": "com.operasoftware.OperaNeon",
+                    "code_signing_team_identifier": "A2P9LX4JPN",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.operasoftware.OperaNeon/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                4,
+                1
+            ]
+        },
+        {
+            "long_name": "Opera Neon Developer",
+            "short_name": "Opera Neon Developer",
+            "supported_platforms": [
+                "Mac",
+                "Windows"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.operasoftware.OperaNeonDeveloper",
+                    "code_signing_identifier": "com.operasoftware.OperaNeonDeveloper",
+                    "code_signing_team_identifier": "A2P9LX4JPN",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.operasoftware.OperaNeonDeveloper/Default/Extensions"
                 }
             },
             "supported_store_identifiers": [


### PR DESCRIPTION
…owser; correct extension install paths for non-GX Opera browsers

I add "Opera Neon Developer" browser. Based on that browser and previous patterns, add "Opera Neon".

While here, I noticed that the non-GX Opera browsers inherited the "no-/Default/" path rule from Opera GX, which is incorrect, so I've fixed those.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update