### PR TITLE
feat: Add support for CocCoc browser to web-browser-extension-distribution-information.json

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -915,6 +915,26 @@
             "supported_store_identifiers": [
                 1
             ]
+        },
+        {
+            "long_name": "CocCoc Browser",
+            "short_name": "CocCoc",
+            "supported_platforms": [
+                "Mac",
+                "Windows",
+                "Linux"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.coccoc.Coccoc",
+                    "code_signing_identifier": "com.coccoc.Coccoc",
+                    "code_signing_team_identifier": "477H9TWJ76",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/CocCoc/Browser/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1
+            ]
         }
     ]
 }


### PR DESCRIPTION
Check this website for details https://coccoc.com/en/desktop

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

<img width="977" height="853" alt="image" src="https://github.com/user-attachments/assets/f1baf274-b4a4-4c22-bfe9-2662cb82d4f2" />
