### PR TITLE
Update password-rules.json for BlueCross BlueShield of NM

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -782,6 +782,9 @@
     "myaccess.dmdc.osd.mil": {
         "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
+    "mybam.bcbsnm.com": {
+        "password-rules": "minlength: 8; maxlength: 64; max-consecutive: 2; required: lower; required: upper; required: digit; allowed: [!#$%&()*@[^{}~];"
+    },
     "mygoodtogo.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper, digit;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

BlueCross BlueShield of New Mexico has password rules that break common assumptions (in particular, you can't use a dash/hyphen, which breaks the usual sorts of secure passwords generated on Apple platforms)

There are additional rules they enforce that I could not figure out how to encode in these rules (like banning 5 or more digits and some specific phrases).  However, using the Password Rules Validation Tool it seems like these are unlike to be generated.

![bcbsnm-pw-rules](https://github.com/user-attachments/assets/e408b5a5-90db-4d74-9b29-9b13c1f4f63b)
