### PR TITLE
Update password-rules.json for cardcash.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -197,6 +197,9 @@
     "cardbenefitservices.com": {
         "password-rules": "minlength: 7; maxlength: 100; required: lower, upper; required: digit;"
     },
+    "cardcash.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!$%&*?@];"
+    },
     "carrefour.it": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

This website requires a special character but doesn't count `-` so the out-of-the-box password generation behavior for Apple Passwords doesn't create a password acceptable to the website.  Verified with three passwords generated by the validation tool.

![cardcash-pw-rules](https://github.com/user-attachments/assets/cb95f9bc-dd04-48fd-90a9-3b1a64bba556)
