### PR TITLE
Update password-rules.json for mypatientvisit.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -791,6 +791,9 @@
     "myhealthrecord.com": {
         "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
     },
+    "mypatientvisit.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*+.;?@^_~];"
+    },
     "mypay.dfas.mil": {
         "password-rules": "minlength: 9; maxlength: 30; required: lower; required: upper; required: digit; required: [#@$%^!*+=_];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Website requires a special character, but doesn't recognize `-` as valid.  Three test cases from validation tool passed the website's client-side check for validity.

Screenshot shows website rejecting auto-generated password with default rules (doesn't recognize `-` as a special character).

![mypatientvisit-pw-reqs](https://github.com/user-attachments/assets/470e3cb1-29f6-4452-b849-8b6df0150056)
