### PR TITLE
Update password-rules.json for id.westfield.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -623,6 +623,9 @@
     "id.sonyentertainmentnetwork.com": {
         "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
     },
+    "id.westfield.com": {
+        "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; required: [!\"#&'()*,./:;?@[\\^_`{|}~];"
+    },
     "identity.codesignal.com": {
         "password-rules": "minlength: 14; required: digit; required: lower, upper; required: [!#$%&*@^]"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

per the request in #921 

This website will recognize _many_ special characters, but not the `-` character!  As you can see in the javascript they're using, technically there are other characters which could be used.  However, the Password Rules Validation Tool did not seem to appreciate many of them (such as '«'), so this only includes the special characters that the validation tool filtered down to. 

![westfield-pw-reqs](https://github.com/user-attachments/assets/83e5b1c4-3e67-44e2-a38c-de76706618da)

