### PR TITLE
Add support for Comet Canary and Comet Dev

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -917,6 +917,42 @@
             ]
         },
         {
+            "long_name": "Comet Canary",
+            "short_name": "Comet Canary",
+            "supported_platforms": [
+                "Mac"
+            ],
+             "platform_specific_information": {
+                 "Mac": {
+                     "bundle_identifier": "ai.perplexity.comet-canary",
+                     "code_signing_identifier": "ai.perplexity.comet-canary",
+                     "code_signing_team_identifier": "7S8W4W365S",
+                     "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet Canary/Default/Extensions"
+                 }
+             },
+            "supported_store_identifiers": [
+                1
+            ]
+        },
+        {
+            "long_name": "Comet Dev",
+            "short_name": "Comet Dev",
+            "supported_platforms": [
+                "Mac"
+            ],
+             "platform_specific_information": {
+                 "Mac": {
+                     "bundle_identifier": "ai.perplexity.comet-dev",
+                     "code_signing_identifier": "ai.perplexity.comet-dev",
+                     "code_signing_team_identifier": "7S8W4W365S",
+                     "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet Dev/Default/Extensions"
+                 }
+             },
+            "supported_store_identifiers": [
+                1
+            ]
+        },
+        {
             "long_name": "CocCoc Browser",
             "short_name": "CocCoc",
             "supported_platforms": [


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->
Added support for browsers Comet Canary and Comet Dev, alongside already existing Comet (stable).

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update