### PR TITLE
Update password-rules.json for zenni optical

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -113,6 +113,9 @@
     "auth.readymag.com": {
         "password-rules": "minlength: 8; maxlength: 128; required: lower; required: upper; allowed: special;"
     },
+    "auth.zennioptical.com": {
+        "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; allowed: special;"
+    },
     "autify.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&'()*+,./:;<=>?@[^_`{|}~]];"
     },


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

This website only requires upper/lower/digit: 
![zenni-pw-rules](https://github.com/user-attachments/assets/00a310c3-8430-4b82-9455-aac8699d6001)

However, their client-side javascript appears to allow essentially any special character:

```javascript
        class FusionAuthPasswordChecker {
          constructor(minLength, maxLength, requireMixedCase, requireNonAlpha, requireNumber) {
            this.rules = { minLength, maxLength, requireMixedCase, requireNonAlpha, requireNumber };
          }

          validate(password) {
            const messages = [];
            let valid = true;

            if (password.length < this.rules.minLength || password.length > this.rules.maxLength) {
              messages.push(this.rules.minLength + ' to ' + this.rules.maxLength + ' characters long');
              valid = false;
            }

            if (this.rules.requireMixedCase && !/[A-Z]/.test(password)) {
              messages.push('One uppercase character');
              valid = false;
            }

            if (this.rules.requireMixedCase && !/[a-z]/.test(password)) {
              messages.push('One lowercase character');
              valid = false;
            }

            if (this.rules.requireNumber && !/[0-9]/.test(password)) {
              messages.push('One number');
              valid = false;
            }

            if (this.rules.requireNonAlpha && !/[^A-Za-z0-9]/.test(password)) {
              messages.push('One special character.');
              valid = false;
            }

            return { valid, messages };
          }
        }

        const minLength = 8;
        const maxLength = 14; 
        const requireMixedCase = true;
        const requireNonAlpha = false;
        const requireNumber = true;
```

For example:
![howdy-pw](https://github.com/user-attachments/assets/ffe4625f-694a-4eb5-a30d-589f0d50c4e0)

I tested a dozen passwords from the Password validation tool and the client-side javascript accepted them all.  However, I did not want to potentially mess up my account if this validation isn't great, so I did not submit any changes for any server-side validation, nor did I want to create a dummy account.

