### PR TITLE
Update password-rules.json for NM Lottery website

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -902,6 +902,9 @@
     "pret.com": {
         "password-rules": "minlength: 12; required: lower; required: digit; required: [@$!%*#?&]; allowed: upper;"
     },
+    "promozoneapp.nmlottery.com": {
+        "password-rules:" "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
+    },
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -903,7 +903,7 @@
         "password-rules": "minlength: 12; required: lower; required: digit; required: [@$!%*#?&]; allowed: upper;"
     },
     "promozoneapp.nmlottery.com": {
-        "password-rules:" "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
+        "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
     },
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

The rules given on the website:
![nmlottery-rules](https://github.com/user-attachments/assets/fc78e4f8-0fe6-46e7-b86e-8263db90143c)

This matches the client-side validation javascript:
![nmlottery-javascript](https://github.com/user-attachments/assets/12b87dd1-a7b3-4649-9667-f841643be496)

Experimentally, I verified that they allow passwords with special characters.  Technically, only one of upper or lower would be required, but it seems better to have them both as required (along with the optional special character) vs. trying to strictly encode rules that would only serve to generate weaker passwords (but willing to make changes if that's not in the spirit).