### PR TITLE
Add password rule for vanguard.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -974,6 +974,9 @@
     "secure.snnow.ca": {
         "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper;"
     },
+    "security-settings.web.vanguard.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special;"
+    },
     "sephora.com": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Addresses issue: #954 

https://security-settings.web.vanguard.com/username-password

The rules given on the website:

<img width="553" height="38" alt="486939700-2b28156e-1d09-4be3-a3d5-046d1a7faaec" src="https://github.com/user-attachments/assets/1cc2cf4f-cca7-4c55-b27f-55b8edaa98c1" />

I wasn't able to test it on the website itself since it redirects to https://login.vanguard.com.


