### PR TITLE
Updating shared-credentials.json for Hawaiian Airlines frequent flyer account merger with Alaska Airline's Atmo Rewards

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -364,6 +364,15 @@
     },
     {
         "from": [
+            "hawaiianairlines.com"
+        ],
+        "to": [
+            "alaskaair.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "hbo.com",
             "hbomax.com",
             "hbonow.com"
@@ -758,15 +767,6 @@
         ],
         "to": [
             "ynab.com"
-        ],
-        "fromDomainsAreObsoleted": true
-    },
-    {
-        "from": [
-            "hawaiianairlines.com"
-        ],
-        "to": [
-            "alaskaair.com"
         ],
         "fromDomainsAreObsoleted": true
     }


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ ] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

When a user attempts to log into their frequent flyer account with Hawaiian Airlines, it redirects them to an Alaska Airlines hosted website (as the Alaska Airlines hosted website contains the Hawaiian Airlines frequent flyer accounts now, as part of Atmos Rewards).