### PR TITLE
Add monarch.com and monarchmoney.com to shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -489,6 +489,12 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "shared": [
+            "monarch.com",
+            "monarchmoney.com"
+        ]
+    },
+    {
         "from": [
             "moneybird.nl",
             "moneybird.de"


### PR DESCRIPTION
They're the same entity. Based on an email communication from the service, I can see that monarchmoney.com is being phased out, but is still active at this time. Thus, a shared group.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.