### PR TITLE
Add password rules for bkvenergy.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -168,7 +168,7 @@
         "password-rules": "minlength: 6; required: lower; required: upper; required: digit; required: [`!@#$%^&*()+~{}'\";:<>?]];"
     },
     "bkvenergy.com": {
-        "password-rules": "minlength: 8; maxlength: 12; required: upper; required: lower; required: digit; required: [~!@#$%^&*()_=+,<.>- ];"
+        "password-rules": "minlength: 8; maxlength: 12; required: upper; required: lower; required: digit; required: [-~!@#$%^&*()_=+,<.> ];"
     },
     "blackwells.co.uk": {
         "password-rules": "minlength: 8; maxlength: 30; allowed: upper,lower,digit;"


### PR DESCRIPTION
Added necessary rules for bkvenergy.com

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

URL: https://bkvenergy.com/account/register/

This website has a pretty narrow restriction on password length, which I think was the main thing preventing the auto-generated passwords from working. Created a rule that includes all the specified requirements, and test passwords are passing.

<img width="302" height="302" alt="CleanShot 2025-10-22 at 10 59 39@2x" src="https://github.com/user-attachments/assets/23ce5914-4218-4d66-b5ba-f052fe9f354c" />
