### PR TITLE
Clarify that the process that does extension native messaging for Cha…

### DIFF
--- a/quirks/schemas/web-browser-extension-distribution-information-schema.json
+++ b/quirks/schemas/web-browser-extension-distribution-information-schema.json
@@ -56,6 +56,12 @@
                   "code_signing_team_identifier": {
                     "type": "string"
                   },
+                  "extension_native_messaging_process_bundle_identifier": {
+                    "type": "string"
+                  },
+                  "extension_native_messaging_process_code_signing_identifier": {
+                    "type": "string"
+                  },
                   "extensions_install_path_relative_to_user_library_directory": {
                     "type": "string"
                   }

--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -982,7 +982,9 @@
                 "Mac": {
                     "bundle_identifier": "com.openai.atlas",
                     "code_signing_identifier": "com.openai.atlas",
-                    "code_signing_team_identifier": "2DC432GLL2"
+                    "code_signing_team_identifier": "2DC432GLL2",
+                    "extension_native_messaging_process_bundle_identifier": "com.openai.atlas.web",
+                    "extension_native_messaging_process_code_signing_identifier": "com.openai.atlas.web"
                 }
             },
             "supported_store_identifiers": [


### PR DESCRIPTION
…tGPT Atlas is another process

This adds extension_native_messaging_process_bundle_identifier and extension_native_messaging_process_code_signing_identifier as optional keys in the "Mac" "platform_specific_information" object.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update