### PR TITLE
Add Snapchat change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -377,6 +377,7 @@
     "shutterfly.com": "https://www.shutterfly.com/account-settings/",
     "sipgatebasic.de": "https://app.sipgatebasic.de/settings",
     "slickdeals.net": "https://slickdeals.net/forums/login.php?do=lostpw",
+    "snapchat.com": "https://accounts.snapchat.com/accounts/change_password",
     "soap2day.to": "https://soap2day.to/home/user/changepassword",
     "solitaired.com": "https://solitaired.com/user/reset-password?",
     "sonos.com": "https://www.sonos.com/myaccount/user/profile/",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [X] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [X] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state