### PR TITLE
Add password rules for Aesop

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -30,7 +30,7 @@
         "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit;"
     },
     "aesop.com": {
-        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [(!@#$%&?];"
+        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!@#$%&?];"
     },
     "aetna.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: upper; required: digit; allowed: lower, [-_&#@];"


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="692" height="75" alt="image" src="https://github.com/user-attachments/assets/54af84f1-7d77-462e-bba4-552a2a74479d" />
