### PR TITLE
add support for Norton, Neo, Avast, Avira, and AVG browsers

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -1014,8 +1014,7 @@
             "short_name": "Neo",
             "supported_platforms": [
                 "Mac",
-                "Windows",
-                "Linux"
+                "Windows"
             ],
             "platform_specific_information": {
                 "Mac": {


### PR DESCRIPTION
I want to add iCloud Passwords support for Norton, Neo, Avast, Avira, and AVG browsers.  This PR is to address #983 

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update


