### PR TITLE
Update shared-credentials.json for flaglerclerk.gov migration

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -324,6 +324,15 @@
     },
     {
         "from": [
+            "flaglerclerk.com"
+        ],
+        "to": [
+            "flaglerclerk.gov"
+        ],
+        "fromDomainsAreObsoleted": false
+    },
+    {
+        "from": [
             "flyblade.com"
         ],
         "to": [


### PR DESCRIPTION
Added migration from flaglerclerk.com to flaglerclerk.gov

- [ X ] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [ X ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

flaglerclerk.com will be migrating to flaglerclerk.gov in early 2026. Subdomains are redirected (or linked to) from flaglerclerk.com to flaglerclerk.gov (ex. cases.flaglerclerk.gov on homepage of flaglerclerk.com, status.flaglerclerk.com redirecting to status.flaglerclerk.gov). 