### PR TITLE
Add password rules for aqara.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -104,6 +104,9 @@
     "appleloan.citizensbank.com": {
         "password-rules": "minlength: 10; maxlength: 20; max-consecutive: 2; required: lower; required: upper; required: digit; required: [!#$%@^_];"
     },
+    "aqara.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: upper,lower; required: digit,special;"
+    },
     "areariservata.bancaetica.it": {
         "password-rules": "minlength: 8; maxlength: 10; required: lower; required: upper; required: digit; required: [!#&*+/=@_];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="1080" height="842" alt="Aqara" src="https://github.com/user-attachments/assets/f40ee12a-22fc-43aa-a9a2-66ba9f280b9b" />

