### PR TITLE
Add password rules for eki-net.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -362,6 +362,9 @@
     "edistrict.kerala.gov.in": {
         "password-rules": "minlength: 5; maxlength: 15; required: lower; required: upper; required: digit; required: [!@#$];"
     },
+    "eki-net.com": {
+        "password-rules": "minlength: 6; maxlength: 12; required: digit; required: upper,lower;"
+    },
     "empower-retirement.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [X] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [X] The top-level JSON objects are sorted alphabetically
- [X] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [X] The given rule isn't particularly standard and obvious for password managers
- [X] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [X] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [X] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="1422" height="1774" alt="eki-net com" src="https://github.com/user-attachments/assets/100bccf0-46ba-47ad-831f-97e5fbf70b4d" />

`記号を除く半角・英数字混在（6〜12文字）` means `Must be 6–12 characters long and contain both letters (A–Z, a–z)
and digits (0–9) only.`