### PR TITLE
Add Kiwibank.co.nz password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -701,6 +701,9 @@
     "kingsfoodmarkets.com": {
         "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
+    "kiwibank.co.nz": {
+        "password-rules": "minlength: 6; maxlength: 15; required: digit; required: digit; required: upper,lower; required: upper,lower;"
+    },
     "klm.com": {
         "password-rules": "minlength: 8; maxlength: 12;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

Hey folks!

I've added a password rule for Kiwibank.co.nz. Their password rules require two digits and two letters, which I couldn't find an obvious way to fully express in the [password rules documentation](https://developer.apple.com/documentation/security/customizing-password-autofill-rules), as discussed in #685. I've gotten as close as I can.

Most, but importantly not **all**, of the [example passwords](https://developer.apple.com/password-rules/) I tested worked. Those that didn't failed the two digit requirement. There also appears to be an undocumented list of disallowed special characters. Since testing this requires actually changing passwords (the page doesn’t show it upfront), I haven’t tested thoroughly enough to identify the full list.

I welcome any feedback!

– droggs

<img width="1275" height="777" alt="Screenshot 2025-12-28 at 11 33 15 AM" src="https://github.com/user-attachments/assets/da6dd60e-df58-497d-9be1-64e2009f5b0d" />
