### PR TITLE
Resolve #997; ParkSmarter.com Needs Quirks #997

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -863,6 +863,9 @@
     "packageconciergeadmin.com": {
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },
+    "parksmarter.com": {
+        "password-rules": "minlength: 8; maxlength: 50; required: upper; required: digit; required: [!@#$%^&]; allowed: lower;"
+    },
     "pavilions.com": {
         "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },


### PR DESCRIPTION
Information about the website's requirements can be found in issue #997.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)