### PR TITLE
Add password generation rules for umopass.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1109,6 +1109,9 @@
     "udel.edu": {
         "password-rules": "minlength: 12; maxlength: 30; required: lower; required: upper; required: digit; required: [!@#$%^&*()+];"
     },
+    "umopass.com": {
+        "password-rules": "minlength: 8; required: upper; required: lower; required: digit; required: [!@#$%^];"
+    },
     "umterps.evenue.net": {
         "password-rules": "minlength: 14; required: digit; required: upper; required: lower; required: [-~!@#$%^&*_+=`|(){}:;];"
     },


### PR DESCRIPTION
Their website states the rules as:
• A minimum of 8 characters
• At least one capital letter
• At least one lower case letter
• At least one number
• At least one special character (@#$%^)

<img width="603" height="1226" alt="image" src="https://github.com/user-attachments/assets/d2e131e3-7cc8-4436-9644-14f2e67df2f0" />

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)