### PR TITLE
Add password rules for online.schoolsfirstfcu.org

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -855,7 +855,7 @@
         "password-rules": "minlength: 6; maxlength: 20; allowed: lower, upper, digit;"
     },
     "online.schoolsfirstfcu.org": {
-        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [!#$%'()*+,/=?[_`]];"
+        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [-!#$%'()*+,/=?[^_`]];"
     },
     "order.wendys.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; allowed: [!#$%&()*+/=?^_{}];"


### PR DESCRIPTION
I'm making this rule because 1Password generated a password using the @ symbol, which is not allowed. Github's editor added the EOL at the end of the file.

I'm being slightly more strict, because they allow 3 of the 4 required classes, and I make all 4 required.
* 0-9 (at least one number)
* A-Z (at least one upper case character)
* a-z (at least one lowercase character)
* !#$%*'^()-_+='/?,[] (at least one special character)

Do Not Use:
* Your Member ID or Username
* Any three prior passwords
* White spaces
* Invalid special characters:
```
<>~@.&:;|"\{}
```

<img width="399" height="414" alt="Screenshot 2026-01-14 at 9 41 49 AM" src="https://github.com/user-attachments/assets/c3114916-428e-4a4a-af13-159f1959daa9" />


<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)