### PR TITLE
Add password rules for websale.cinestar.cz

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1178,6 +1178,9 @@
     "web.de": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },
+    "websale.cinestar.cz": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: digit; allowed: upper, [-!@#$%&*_+=<>];"
+    },
     "wegmans.com": {
         "password-rules": "minlength: 8; required: digit; required: upper,lower; required: [!#$%&*+=?@^];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

The rules for websale.cinestar.cz as seen on https://websale.cinestar.cz/register:

- Must contain 8 to 16 characters.
- At least one letter.
- At least one number.
- Not the same as an email address.

<img width="1682" height="445" alt="image" src="https://github.com/user-attachments/assets/c76f2960-21d2-4096-9566-5b9da98d8181" />
<img width="1088" height="413" alt="image" src="https://github.com/user-attachments/assets/d88e9eda-52c5-4bc8-86d1-767752c942b2" />
