### PR TITLE
Add password rules for consular.mfa.gov.cn

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -284,6 +284,9 @@
     "consorsfinanz.de": {
         "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit, [-.];"
     },
+    "consular.mfa.gov.cn": {
+        "password-rules": "minlength: 9; maxlength: 16; required: digit; required: [!@#$^*]; allowed: lower, upper;"
+    },
     "costco.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, [-!#$%&'()*+/:;=?@[^_`{|}~]];"
     },


### PR DESCRIPTION
"Password rules: 9-16 characters, contains at least one digit and at least one special character (!@#$^*). Cannot contain other special characters (-()[]{}  etc)."

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)