### PR TITLE
Add password rules for amundi-ee.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -68,6 +68,9 @@
     "amnh.org": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower; allowed: ascii-printable;"
     },
+    "amundi-ee.com": {
+        "password-rules": "minlength: 6; maxlength: 6; allowed: digit; max-consecutive: 3;"
+    },
     "ana.co.jp": {
         "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
     },


### PR DESCRIPTION
The website says:
> Le mot de passe doit être composé de 6 chiffres.
> Pour des raisons de sécurité, les combinaisons trop simples telles que 123456,111111, une suite de chiffres identiques, votre date de naissance ou encore votre mot de passe précédent seront aussi refusées.

Which, according to Google Translate, roughly is:
> The password must consist of 6 digits.
> For security reasons, overly simple combinations such as 123456, 111111, a sequence of identical digits, your date of birth, or your previous password will also be rejected.

This makes minlength and maxlength of 6 obvious, as well as only allowing digits. I take an educated guess and also include `max-consecutive: 3;` to satisfy the bit about sequences, although I cannot verify this this is always sufficient myself.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)