### PR TITLE
Add airfranceklm.com to the Air France / KLM shared credentials group

### DIFF
--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -251,12 +251,6 @@
     },
     {
         "shared": [
-            "flyingblue.com",
-            "klm.com"
-        ]
-    },
-    {
-        "shared": [
             "fnac.com",
             "fnacspectacles.com"
         ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -99,6 +99,14 @@
     },
     {
         "shared": [
+            "airfrance.com",
+            "airfranceklm.com",
+            "flyingblue.com",
+            "klm.com"
+        ]
+    },
+    {
+        "shared": [
             "airnewzealand.co.nz",
             "airnewzealand.com",
             "airnewzealand.com.au"
@@ -449,13 +457,6 @@
             "deel.com"
         ],
         "fromDomainsAreObsoleted": true
-    },
-    {
-        "shared": [
-            "login.airfrance.com",
-            "login.flyingblue.com",
-            "login.klm.com"
-        ]
     },
     {
         "shared": [


### PR DESCRIPTION
I discovered the need for this association on a flight just now, where I created an account and then signed in with it. While here, I generalize across the eTLD+1, because I observed the existence of freewifi.airfrance.com. This is an active association, not a historical one.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)