### PR TITLE
Fix XSS vulnerability in CustomCharacterClass.toHTMLString()

### DIFF
--- a/tools/PasswordRulesParser.js
+++ b/tools/PasswordRulesParser.js
@@ -27,6 +27,14 @@ const RuleName = {
     MAX_LENGTH: "maxlength",
 };
 
+const HTMLEntity = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    "\"": "&quot;",
+    "'": "&#x27;"
+};
+
 const CHARACTER_CLASS_START_SENTINEL = "[";
 const CHARACTER_CLASS_END_SENTINEL = "]";
 const PROPERTY_VALUE_SEPARATOR = ",";
@@ -66,7 +74,7 @@ class CustomCharacterClass {
     }
     get characters() { return this._characters; }
     toString() { return `[${this._characters.join("")}]`; }
-    toHTMLString() { return `[${this._characters.join("").replace(/"/g, "&quot;")}]`; }
+    toHTMLString() { return `[${this._characters.join("").replace(/[&<>"']/g, (m) => HTMLEntity[m])}]`; }
 };
 
 // MARK: Lexer functions


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

### Summary
This PR fixes a potential Cross-Site Scripting (XSS) vulnerability in the password rules parser tool.

Previously, the HTML output for custom character classes only escaped double quotes (`"`). However, the parser allows various ASCII printable characters (such as `<`, `>`, `&`, and `'`) that have special meaning in HTML. If a consumer uses this output in an HTML context (e.g., via `innerHTML`), it could lead to XSS.

### Changes
- Updated the HTML serialization logic to properly escape `&`, `<`, `>`, `"`, and `'`.
- Extracted the character mapping into a dedicated top-level constant.

### Impacts
- This prevents XSS when password rules containing special characters are rendered in a UI.

Fixes #1018
