### PR TITLE
Add change password URL for x.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -476,6 +476,7 @@
     "worldwinner.com": "https://www.worldwinner.com/cgi/finance/account.pl",
     "wsj.com": "https://customercenter.wsj.com/account#password",
     "wunderground.com": "https://www.wunderground.com/member/settings",
+    "x.com": "https://x.com/settings/password",
     "xero.com": "https://identity.xero.com/account/?AccountUrl=/!xkcD/Settings/MyAccount",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",
     "xhamster.com": "https://xhamster.com/password-recovery",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state