### PR TITLE
Fix instagram.com change password URL quirk

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -240,7 +240,7 @@
     "independent.co.uk": "https://www.independent.co.uk/profile",
     "insider.com": "https://www.insider.com/",
     "instacart.com": "https://www.instacart.com/store/account",
-    "instagram.com": "https://www.instagram.com/accounts/password/change/",
+    "instagram.com": "https://accountscenter.instagram.com/password_and_security/password/change/",
     "intuit.com": "https://accounts.intuit.com/app/account-manager/security/password",
     "istockphoto.com": "https://www.istockphoto.com/change-password",
     "jcpenney.com": "https://www.jcpenney.com/account/dashboard/personal/info",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state