### PR TITLE
Add shared credentials for Wester domains

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -728,6 +728,12 @@
     },
     {
         "shared": [
+            "dwmall.westjr.co.jp",
+            "wester.jr-odekake.net"
+        ]
+    },
+    {
+        "shared": [
             "uspowerboating.com",
             "ussailing.org"
         ]


### PR DESCRIPTION
Fixes #965. Adds shared credentials for dwmall.westjr.co.jp and wester.jr-odekake.net domains.