### PR TITLE
Add change password URL for privacy.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -353,6 +353,7 @@
     "portlandgeneral.com": "https://portlandgeneral.com/secure/profile/change-password",
     "poshmark.com": "https://poshmark.com/user/account-info",
     "ppomppu.co.kr": "https://www.ppomppu.co.kr/myinfo/profile.php",
+    "privacy.com": "https://app.privacy.com/reset",
     "prolific.co": "https://app.prolific.co/account/general",
     "proton.me": "https://account.proton.me/u/0/vpn/account-password",
     "prowlapp.com": "https://www.prowlapp.com/settings.php",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state