### PR TITLE
Add Tabbit Browser and Tabbit to web browser extension distribution information

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -1249,6 +1249,42 @@
             "supported_store_identifiers": [
                 1
             ]
+        },
+        {
+            "long_name": "Tabbit Browser",
+            "short_name": "Tabbit Browser",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.tab-browser.Tabbit",
+                    "code_signing_identifier": "com.tab-browser.Tabbit",
+                    "code_signing_team_identifier": "2DE8QTFYGR",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Tabbit Browser/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1
+            ]
+        },
+        {
+            "long_name": "Tabbit",
+            "short_name": "Tabbit",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.tabbit-ai.Tabbit",
+                    "code_signing_identifier": "com.tabbit-ai.Tabbit",
+                    "code_signing_team_identifier": "2DE8QTFYGR",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Tabbit/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1
+            ]
         }
     ]
 }


### PR DESCRIPTION
This PR adds two Chromium-based macOS browsers built from the same codebase, targeting different markets:

**Tabbit Browser** — China domestic distribution
- Website: https://www.tabbit-ai.com/
- Bundle ID: `com.tab-browser.Tabbit`
- Team ID: `2DE8QTFYGR`
- Extensions path: `Application Support/Tabbit Browser/Default/Extensions`

**Tabbit** — International distribution
- Website: https://www.tabbitbrowser.com/
- Bundle ID: `com.tabbit-ai.Tabbit`
- Team ID: `2DE8QTFYGR`
- Extensions path: `Application Support/Tabbit/Default/Extensions`

Note: The website domains and bundle IDs may appear swapped, but this is intentional — the domains were reassigned between the two distributions after the initial bundle IDs were established.

Both entries share the same Apple Developer Team ID (`2DE8QTFYGR`) as they are built and signed by the same organization.