### PR TITLE
Add credentials migration from cleanshot.cloud to cleanshot.com

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -192,6 +192,15 @@
         ]
     },
     {
+        "from": [
+            "cleanshot.cloud"
+        ],
+        "to": [
+            "cleanshot.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "coolblue.nl",
             "coolblue.be",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [X] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [X] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

### Evidence: 
- 307 redirect from https://cleanshot.cloud/ to https://cleanshot.com/cloud/
- Notice on [cleanshot.com/cloud/login](https://cleanshot.com/cloud/login)
- Post on [cleanshot.com/blog/cleanshot-cloud-domain-change](https://cleanshot.com/blog/cleanshot-cloud-domain-change)


### Affiliation proof:
- Pull Request from @mtwteam organization repo, which has the `mtw.team` domain verified, which is linked in the [cleanshot.com](https://cleanshot.com/) footer.

Fixes #1033 