### PR TITLE
Change password URLs — Fix fedex.com, remove ups.com, and add zoom.us

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -190,7 +190,7 @@
     "familysearch.org": "https://www.familysearch.org/identity/settings/account",
     "fandom.com": "https://auth.fandom.com/auth/settings",
     "fanfiction.net": "https://www.fanfiction.net/account/password.php",
-    "fedex.com": "https://www.fedex.com/en-us/create-account/how-to-reset-forgot-password.html",
+    "fedex.com": "https://www.fedex.com/profile/en-us/#/login",
     "fetlife.com": "https://fetlife.com/settings/account/password",
     "fidelity.com": "https://fps.fidelity.com/ftgw/Fps/Fidelity/RtlCust/ChangePIN/Init",
     "finance.yahoo.com": "https://login.yahoo.com/myaccount/security/change-password/?src=finance",
@@ -465,7 +465,6 @@
     "uml.edu": "https://mypassword.uml.edu/#Change",
     "umsystem.edu": "https://password.umsystem.edu/reset/",
     "united.com": "https://www.united.com/ual/en/US/account/security/setpassword",
-    "ups.com": "https://www.ups.com/lasso/updatePass?loc=en_US",
     "usaa.com": "https://www.usaa.com/inet/ent_auth_password/pages/ChangePasswordPage",
     "usatoday.com": "https://login.usatoday.com/USAT-GUP/password-forgot/",
     "uscis.gov": "https://myaccount.uscis.gov/users/registration/password",
@@ -514,5 +513,6 @@
     "zillow.com": "https://www.zillow.com/myzillow/profile/",
     "ziprecruiter.com": "https://www.ziprecruiter.com/login/forgot-password?realm=candidates",
     "zocdoc.com": "https://www.zocdoc.com/patient/editprofile?section=Password",
+    "zoom.us": "https://zoom.us/profile",
     "zulily.com": "https://www.zulily.com/account/edit?rel=top_flyout"
 }


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

1. fedex.com's previous entry took you to a guide for changing a password and not the actual change password page.
2. ups.com took you to a broken page that was a change password form, but it wasn't tied to account login, so it threw an error on submission. I could not find a working URL, so I removed it.
3. Add a zoom.us URL