### PR TITLE
Add ipass to web-browser-extension-distribution-information.json

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -1210,6 +1210,21 @@
             "supported_store_identifiers": [
                 1
             ]
+        },
+        {
+            "long_name": "ipass",
+            "short_name": "ipass",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "io.github.kezhenxu94.ipass",
+                    "code_signing_identifier": "io.github.kezhenxu94.ipass",
+                    "code_signing_team_identifier": "58JAK95Y3A"
+                }
+            },
+            "supported_store_identifiers": []
         }
     ]
 }


### PR DESCRIPTION
## Summary

[ipass](https://github.com/kezhenxu94/ipass) is a small open-source CLI tool that allows users to access their iCloud Keychain passwords from the terminal on macOS. It works by spawning `PasswordManagerBrowserExtensionHelper` and communicating with it over native messaging — the same mechanism that Chrome and Firefox browser extensions use.

macOS 26 (Tahoe) introduced kernel-enforced parent launch constraints on `PasswordManagerBrowserExtensionHelper`, requiring the parent process to be listed in this file. Without this entry, AMFI terminates the helper immediately when ipass tries to spawn it, making the tool non-functional on macOS 26.

I'd really appreciate it if ipass could be included here so that users on macOS 26 can continue using it. Happy to provide any additional information or make any changes you'd like.

## Details

| Field | Value |
|---|---|
| `long_name` / `short_name` | `ipass` |
| `bundle_identifier` | `io.github.kezhenxu94.ipass` |
| `code_signing_identifier` | `io.github.kezhenxu94.ipass` |
| `code_signing_team_identifier` | `58JAK95Y3A` |
| Platform | Mac only |
| `supported_store_identifiers` | `[]` (CLI tool, not distributed via any extension store) |

## Checklist

- [x] `tools/validate-json-schemas.sh` passes