### PR TITLE
Add a password change URL quirk for amazonaws.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -49,6 +49,7 @@
     "amazon.sa": "https://www.amazon.sa/ax/account/manage",
     "amazon.se": "https://www.amazon.se/ax/account/manage",
     "amazon.sg": "https://www.amazon.sg/ax/account/manage",
+    "amazonaws.com": "https://console.aws.amazon.com/iam/home#/security_credentials",
     "amctheatres.com": "https://www.amctheatres.com/amcstubs/account",
     "americanexpress.com": "https://www.americanexpress.com/en-us/account/password/manage",
     "ana.co.jp": "https://cam.ana.co.jp/psz/us/amc_us.jsp?index=105",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

The well-known password change URL currently just redirects to the homepage. This quirked URL instead takes the user directly to the Security Credentials pane in the AWS console, where there's an option to change the password.