### PR TITLE
Add melio.com password rules and shared credentials with meliopayments.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -785,6 +785,9 @@
     "meineschufa.de": {
         "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: [!?#%$];"
     },
+    "melio.com": {
+        "password-rules": "minlength: 8; required: upper; required: lower; required: digit; required: special;"
+    },
     "member.everbridge.net": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -785,9 +785,6 @@
     "meineschufa.de": {
         "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: [!?#%$];"
     },
-    "melio.com": {
-        "password-rules": "minlength: 8; required: upper; required: lower; required: digit; required: special;"
-    },
     "member.everbridge.net": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; allowed: [!@#$%^&*()];"
     },

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -468,6 +468,12 @@
         ]
     },
     {
+        "shared": [
+            "melio.com",
+            "meliopayments.com"
+        ]
+    },
+    {
         "from": [
             "mercadolibre.cl",
             "mercadolibre.co.cr",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others.

---

## Shared Credentials: melio.com and meliopayments.com

Melio operates under two domains:
- **melio.com** - primary domain (login at `accounts.melio.com`)
- **meliopayments.com** - legacy domain (login at `app.meliopayments.com`)

Both domains serve login pages that accept the same user credentials. The top-level domain `melio.com` redirects to `meliopayments.com`. Both domains are owned and operated by Melio Payments, Inc.

I am a developer at Melio and can confirm these domains share a credential backend.