### PR TITLE
Add change password URL quirk for tudogostoso.com.br

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -459,6 +459,7 @@
     "tripadvisor.com": "https://www.tripadvisor.com/Settings-cp",
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
     "trulia.com": "https://www.trulia.com/account/user_profile",
+    "tudogostoso.com.br": "https://profile.tudogostoso.com.br/editar_perfil.htm",
     "tum.de": "https://campus.tum.de",
     "tumblr.com": "https://www.tumblr.com/settings/account",
     "turkishairlines.com": "https://www.turkishairlines.com/tr-int/miles-and-smiles/forgot-password/",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
