### PR TITLE
Add Stores.com shared-credentials entry

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -181,6 +181,20 @@
     },
     {
         "shared": [
+            "casemates.com",
+            "hammacher.com",
+            "mediocre.com",
+            "mediocre.org",
+            "meh.com",
+            "mercatalyst.com",
+            "morningsave.com",
+            "shop.univision.com",
+            "sidedeal.com",
+            "stores.com"
+        ]
+    },
+    {
+        "shared": [
             "centralfcu.org",
             "centralfcu.com"
         ]


### PR DESCRIPTION
Stores.com operates these 10 domains and credentials are shared across all of them — an account registered on any one can sign in on any of the others. See https://stores.com.