### PR TITLE
Fix the lowes.com password change URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -277,7 +277,7 @@
     "live.com": "https://account.live.com/password/change?refd=account.microsoft.com&fref=home.banner.changepwd",
     "livejasmin.com": "https://www.livejasmin.com/en/girls/#!settings/account",
     "login.gov": "https://secure.login.gov/manage/password",
-    "lowes.com": "https://www.lowes.com/mylowes/profile",
+    "lowes.com": "https://www.lowes.com/security/settings",
     "lu.ma": "https://lu.ma/settings",
     "macys.com": "https://www.macys.com/account/profile?cm_sp=macys_account-_-my_account-_-my_profile&linklocation=leftrail",
     "marketwatch.com": "https://customercenter.marketwatch.com/account#password?mod=ql",


### PR DESCRIPTION
https://www.lowes.com/security/settings takes the user directly to the password change UI, whereas https://www.lowes.com/mylowes/profile loads the user profile.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state