### PR TITLE
Add a password change URL quirk for carmax.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -109,6 +109,7 @@
     "canva.com": "https://www.canva.com/login?redirect=%2Fsettings%2Flogin-and-security",
     "capitalone.com": "https://myaccounts.capitalone.com/Security/changePassword",
     "cargurus.com": "https://www.cargurus.com/Cars/myAccount#/accountSettings",
+    "carmax.com": "https://www.carmax.com/myaccount/login/svc/oidc/password/change",
     "carnival.com": "https://www.carnival.com/profilemanagement/profiles/changepassword",
     "cars.com": "https://www.cars.com/reset_password",
     "carta.com": "https://app.carta.com/profiles/update/",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -215,6 +215,9 @@
     "cardcash.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!$%&*?@];"
     },
+    "carmax.com": {
+        "password-rules": "minlength: 8; maxlength: 64; required: upper,lower; required: digit; allowed: [@$!%*#?&^'_+=;:,.~/\\|{}()[\\]];"
+    },
     "carrefour.it": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
     },


### PR DESCRIPTION
The password change rule is derived from the pattern attribute of the new password field:

```
^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d@$!%*#?&^'_+=;:,.~\/`\|\{\}\[\]\)\(\\]{8,64}$
```

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state