### PR TITLE
Update the change password URL for ulta.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -470,7 +470,7 @@
     "udacity.com": "https://classroom.udacity.com/settings/password",
     "udel.edu": "https://udapps.nss.udel.edu/myUDsettings/password",
     "uline.com": "https://www.uline.com/MyAccount/ContactPref",
-    "ulta.com": "https://www.ulta.com/myaccount/index.jsp",
+    "ulta.com": "https://www.ulta.com/account/manage",
     "uml.edu": "https://mypassword.uml.edu/#Change",
     "umsystem.edu": "https://password.umsystem.edu/reset/",
     "united.com": "https://www.united.com/ual/en/US/account/security/setpassword",


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state