### PR TITLE
Fix hotels.com password change URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -241,7 +241,7 @@
     "homedepot.com": "https://www.homedepot.com/myaccount/security",
     "honeywell.com": "https://honeywell.csod.com/resetPasswrd.aspx?",
     "hosting.com": "https://my.hosting.com/profile/security",
-    "hotels.com": "https://hotels.com/profile/settings.html",
+    "hotels.com": "https://www.hotels.com/login?redirectTo=%2Faccount%2Fsettings",
     "housecallpro.com": "https://pro.housecallpro.com/service_pro/account/reset_password",
     "hp.com": "https://account.id.hp.com/security",
     "hsn.com": "https://www.hsn.com/myaccount/update",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
