### PR TITLE
Add a change password URL quirk for squareup.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -422,6 +422,7 @@
     "splunk.com": "https://www.splunk.com/my-account/#/profile-details",
     "sports.yahoo.com": "https://login.yahoo.com/account/change-password",
     "spotify.com": "https://www.spotify.com/in-en/account/change-password/",
+    "squareup.com": "https://app.squareup.com/dashboard/account",
     "ssa.gov": "https://secure.ssa.gov/RIM/UpwdView.action",
     "stackoverflow.com": "https://stackoverflow.com/users/account-recovery",
     "stacksocial.com": "https://stacksocial.com/user?show=account-tab",


### PR DESCRIPTION
Password change URL: https://app.squareup.com/dashboard/account

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state