### PR TITLE
Remove redundant subdomains from shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -711,8 +711,7 @@
     {
         "shared": [
             "rekordbox.com",
-            "pioneerdj.com",
-            "community.pioneerdj.com"
+            "pioneerdj.com"
         ]
     },
     {
@@ -828,11 +827,10 @@
     },
     {
         "from": [
-          "workflowmanager.app",
-          "login.workflowmanager.app"
+            "workflowmanager.app"
         ],
         "to": [
-          "infotechexpress.com"
+            "infotechexpress.com"
         ]
     },
     {
@@ -840,9 +838,6 @@
             "www.seek.com.au",
             "www.seek.co.nz",
             "jobsdb.com",
-            "hk.jobsdb.com",
-            "sg.jobsdb.com",
-            "th.jobsdb.com",
             "jobstreet.com",
             "myjobstreet.jobstreet.co.id",
             "myjobstreet.jobstreet.com.my",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

### Description of Changes
This PR removes several subdomains from `shared-credentials.json` that are redundant because their parent domains are already present in the exact same credential group. 

Since password manager resources automatically include subdomains when a parent domain is matched, explicitly listing these subdomains alongside their parents is unnecessary.

The removed subdomains are:
* `login.workflowmanager.app` (covered by `workflowmanager.app`)
* `community.pioneerdj.com` (covered by `pioneerdj.com`)
* `hk.jobsdb.com`, `sg.jobsdb.com`, `th.jobsdb.com` (covered by `jobsdb.com`)

No new groups were added; this is strictly an optimization/cleanup of the existing data structure.
