### PR TITLE
Improve password rules validation errors

### DIFF
--- a/.github/workflows/lint-scripts/password-rules-parse.js
+++ b/.github/workflows/lint-scripts/password-rules-parse.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+//
+// Validates every "password-rules" string in quirks/password-rules.json by
+// loading tools/PasswordRulesParser.js and calling parsePasswordRules() on it.
+// Any parse error (e.g. ",required" instead of "; required", as in #907) causes
+// CI to fail with a clear message identifying the offending domain.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+const parserPath = path.join(repoRoot, "tools", "PasswordRulesParser.js");
+const rulesPath = path.join(repoRoot, "quirks", "password-rules.json");
+
+const parserSource = fs.readFileSync(parserPath, "utf8");
+const rules = JSON.parse(fs.readFileSync(rulesPath, "utf8"));
+
+const sandbox = {
+    capturedErrors: [],
+    console: {
+        assert() {},
+        warn() {},
+        error(message) { sandbox.capturedErrors.push(String(message)); },
+    },
+};
+vm.createContext(sandbox);
+vm.runInContext(parserSource, sandbox, { filename: parserPath });
+
+let failedDomains = 0;
+for (const domain of Object.keys(rules)) {
+    const ruleString = rules[domain]["password-rules"];
+    sandbox.capturedErrors.length = 0;
+    sandbox.__ruleString = ruleString;
+    try {
+        vm.runInContext("parsePasswordRules(__ruleString)", sandbox);
+    } catch (e) {
+        sandbox.capturedErrors.push(`threw ${e.message}`);
+    }
+    if (sandbox.capturedErrors.length > 0) {
+        failedDomains++;
+        console.error(`${domain}: ${ruleString}`);
+        for (const message of sandbox.capturedErrors) {
+            console.error(`  ${message}`);
+        }
+    }
+}
+
+if (failedDomains > 0) {
+    console.error(`\n${failedDomains} domain(s) in password-rules.json failed to parse.`);
+    process.exit(1);
+}
+
+console.log(`OK: ${Object.keys(rules).length} password-rules entries parsed cleanly.`);

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,9 @@ jobs:
     - uses: actions/checkout@v6
     - name: Lint Sort Order
       run: cat quirks/password-rules.json | grep "^    \"" | sort -c
+    - uses: actions/setup-node@v6
+    - name: Lint Rule Syntax
+      run: node .github/workflows/lint-scripts/password-rules-parse.js
 
   websites-shared-credentials:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a CI lint step that parses every `"password-rules"` value in `quirks/password-rules.json` using the existing `tools/PasswordRulesParser.js`. Any parse error is reported with the offending domain and the parser's error message, causing the `password-rules` lint job to fail.

This addresses [#907](https://github.com/apple/password-manager-resources/issues/907), where a small formatting error (a comma instead of a semicolon between two `required:` properties for `hetzner.com`) landed without CI catching it and only surfaced later as a downstream parser exception.

The new check piggybacks on the existing `password-rules` job (sort-order check) and adds two steps: `actions/setup-node@v6` and `node .github/workflows/lint-scripts/password-rules-parse.js`. No other lint behavior changes.

## How it works

`password-rules-parse.js` loads `tools/PasswordRulesParser.js` via `node:vm` into a sandbox whose `console.error` is captured. It iterates every domain in `password-rules.json`, calls `parsePasswordRules()`, and exits non-zero if any rule produced a parser error. The parser is loaded unchanged — it remains usable by Safari/WebKit consumers that expect a plain script.

## Test plan

- [x] Run `node .github/workflows/lint-scripts/password-rules-parse.js` on `main` → `OK: 419 password-rules entries parsed cleanly.` (exit 0)
- [x] Reintroduce the original `hetzner.com` comma typo from #907 → script fails with `1 domain(s) in password-rules.json failed to parse.` and identifies `hetzner.com` (exit 1)
- [x] Restore correct value → clean again (exit 0)
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` → YAML valid

## Risks / follow-ups

- The script only fails on `console.error` from the parser; recoverable warnings (e.g. the `console.warn` about a `-` inside a character class) are intentionally ignored to avoid noisy false positives. If desired, a follow-up could promote those to errors.
- This does not introduce any runtime dependencies — it uses only Node built-ins (`fs`, `path`, `vm`).