### PR TITLE
Teach the new lint script, password-rules-parse.js, to fail on common…

### DIFF
--- a/.github/workflows/lint-scripts/password-rules-parse.js
+++ b/.github/workflows/lint-scripts/password-rules-parse.js
@@ -2,8 +2,9 @@
 //
 // Validates every "password-rules" string in quirks/password-rules.json by
 // loading tools/PasswordRulesParser.js and calling parsePasswordRules() on it.
-// Any parse error (e.g. ",required" instead of "; required", as in #907) causes
-// CI to fail with a clear message identifying the offending domain.
+// Any parse error (e.g. ",required" instead of "; required" as in #907, or
+// '-'/']' in the wrong position inside a character class) causes CI to fail
+// with a clear message identifying the offending domain.
 
 "use strict";
 

--- a/tools/PasswordRulesParser.js
+++ b/tools/PasswordRulesParser.js
@@ -333,8 +333,7 @@ function _parseCustomCharacterClass(input, position)
         }
 
         if (c === "-" && (position - initialPosition) > 0) {
-            // FIXME: Should this be an error?
-            console.warn("Ignoring '-'; a '-' may only appear as the first character in a character class");
+            console.error("Ignoring '-'; a '-' may only appear as the first character in a character class");
             ++position;
             continue;
         }
@@ -349,6 +348,12 @@ function _parseCustomCharacterClass(input, position)
     if (position < length && input[position] !== CHARACTER_CLASS_END_SENTINEL || position == length && input[position - 1] == CHARACTER_CLASS_END_SENTINEL) {
         // Fix up result; we over consumed.
         result.pop();
+        if (position < length) {
+            let nextCharacter = input[position];
+            if (!_isASCIIWhitespace(nextCharacter) && nextCharacter !== PROPERTY_VALUE_SEPARATOR && nextCharacter !== PROPERTY_SEPARATOR) {
+                console.error(`A ']' inside a character class must be the last character of the class; if a literal ']' is intended, write ']]' at the end. Found unexpected '${nextCharacter}' after closing ']'.`);
+            }
+        }
         return [result, position];
     }
 
@@ -513,7 +518,7 @@ function _parsePasswordRulesInternal(input)
     var position = _indexOfNonWhitespaceCharacter(input);
     while (position < length) {
         if (!_isIdentifierCharacter(input[position])) {
-            console.warn("Failed to find start of property: " + input.substr(position));
+            console.error("Failed to find start of property: " + input.substr(position));
             return parsedProperties;
         }
 


### PR DESCRIPTION
… character class errors

Two existing warnings are promoted to errors and one new error is added to the parser.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update