### PR TITLE
Add shared-credentials quirk for prtimes.com and prtimes.jp

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -702,6 +702,12 @@
     },
     {
         "shared": [
+            "prtimes.com",
+            "prtimes.jp"
+        ]
+    },
+    {
+        "shared": [
             "quicken.com",
             "simplifimoney.com"
         ]


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others.

### Context

Both `prtimes.jp` and `prtimes.com` are operated by PR TIMES Corporation. PR TIMES is currently migrating its press release service domain from `prtimes.jp` to `prtimes.com`. During the migration the two domains will run in parallel, and the service is eventually planned to be consolidated under `prtimes.com`.

This pull request is submitted by engineers at PR TIMES Corporation.

### Evidence

**Official announcement**

PR TIMES Corporation has publicly announced the domain migration, with the main service transition scheduled to take place from September 2026 onward.

- 月間7000万PV*の「PR TIMES」がサービスドメインを「prtimes.com」へ今秋移行 (Japanese article): https://prtimes.jp/main/html/rd/p/000001644.000000112.html
  - English summary: PR TIMES Corporation has publicly announced the domain migration from `prtimes.jp` to `prtimes.com`, with the main service migration planned for September 2026 onward.

**Shared authentication backend**

Both domains use the same PR TIMES account authentication backend. The login entry points are:

- https://prtimes.jp/main/html/medialogin
- https://prtimes.com/main/html/medialogin

Some authentication flows may redirect between the two domains during the migration.

**Digital Asset Links**

Both domains publish Digital Asset Links (`/.well-known/assetlinks.json`) that explicitly delegate `delegate_permission/common.get_login_creds` to both `https://prtimes.jp` and `https://prtimes.com`, declaring that credentials saved for one domain are intended to be usable on the other:

- https://prtimes.jp/.well-known/assetlinks.json
- https://prtimes.com/.well-known/assetlinks.json

Both files contain identical entries:

```json
[
  {
    "relation": ["delegate_permission/common.get_login_creds"],
    "target": { "namespace": "web", "site": "https://prtimes.jp" }
  },
  {
    "relation": ["delegate_permission/common.get_login_creds"],
    "target": { "namespace": "web", "site": "https://prtimes.com" }
  }
]
```

**Verified behavior**

We (PR TIMES Corporation contributors) have actually verified that the same PR TIMES account credentials are usable across the unified authentication flow on both domains.

### Why `shared` (rather than `from`/`to`)

- During the migration both domains remain active; this is not a one-way redirect where one domain is fully obsolete.
- Credentials saved for either domain are intended to work for the same PR TIMES account across both directions, not only from `prtimes.jp` to `prtimes.com`.