### PR TITLE
Add NPO domains

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -381,6 +381,7 @@
     "nordstrom.com": "https://www.nordstrom.com/my-account/sign-in-info",
     "nordstromrack.com": "https://www.nordstromrack.com/my-account/sign-in-info",
     "norton.com": "https://my.norton.com/extspa/account/personalinfo",
+    "npo.nl": "https://id.npo.nl/account/change-password",
     "npr.org": "https://secure.npr.org/oauth2/login",
     "nvidia.com": "https://profile.nvgs.nvidia.com/security/change-password",
     "nypost.com": "https://nypost.com/account/settings",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -877,5 +877,16 @@
             "ynab.com"
         ],
         "fromDomainsAreObsoleted": true
+    },
+        {
+        "shared": [
+            "eo.nl",
+            "id.npo.nl",
+            "kro-ncrv.nl",
+            "npo.nl",
+            "npo.nl/luister",
+            "npo.nl/start",
+            "wnl.tv"
+        ]
     }
 ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -362,7 +362,6 @@
             "kro-ncrv.nl",
             "l1.nl",
             "npo.nl",
-            "npo.nl/start",
             "npoluister.nl",
             "nporadio5.nl",
             "omroepwest.nl",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -356,6 +356,30 @@
         ]
     },
     {
+        "from": [
+            "eo.nl",
+            "gld.nl",
+            "kro-ncrv.nl",
+            "l1.nl",
+            "npo.nl",
+            "npo.nl/start",
+            "npoluister.nl",
+            "nporadio5.nl",
+            "omroepwest.nl",
+            "omroepzeeland.nl",
+            "omropfryslan.nl",
+            "oost.nl",
+            "rijnmond.nl",
+            "rtvdrenthe.nl",
+            "rtvnoord.nl",
+            "rtvutrecht.nl",
+            "wnl.tv"
+        ],
+        "to": [
+            "id.npo.nl"
+        ]
+    },
+    {
         "shared": [
             "epicgames.com",
             "fortnite.com",
@@ -877,27 +901,5 @@
             "ynab.com"
         ],
         "fromDomainsAreObsoleted": true
-    },
-        {
-        "from": [
-            "eo.nl",
-            "gld.nl",
-            "kro-ncrv.nl",
-            "l1.nl",
-            "npo.nl",
-            "npo.nl/start",
-            "npoluister.nl",
-            "nporadio5.nl",
-            "omroepwest.nl",
-            "omroepzeeland.nl",
-            "omropfryslan.nl",
-            "oost.nl",
-            "rijnmond.nl",
-            "rtvdrenthe.nl",
-            "rtvnoord.nl",
-            "rtvutrecht.nl",
-            "wnl.tv"
-        ],
-        "to": ["id.npo.nl"]
     }
 ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -879,7 +879,25 @@
         "fromDomainsAreObsoleted": true
     },
         {
-        "from": ["eo.nl", "kro-ncrv.nl", "npo.nl", "npo.nl/luister", "npo.nl/start", "wnl.tv"],
+        "from": [
+            "eo.nl",
+            "gld.nl",
+            "kro-ncrv.nl",
+            "l1.nl",
+            "npo.nl",
+            "npo.nl/start",
+            "npoluister.nl",
+            "nporadio5.nl",
+            "omroepwest.nl",
+            "omroepzeeland.nl",
+            "omropfryslan.nl",
+            "oost.nl",
+            "rijnmond.nl",
+            "rtvdrenthe.nl",
+            "rtvnoord.nl",
+            "rtvutrecht.nl",
+            "wnl.tv"
+        ],
         "to": ["id.npo.nl"]
     }
 ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -879,14 +879,7 @@
         "fromDomainsAreObsoleted": true
     },
         {
-        "shared": [
-            "eo.nl",
-            "id.npo.nl",
-            "kro-ncrv.nl",
-            "npo.nl",
-            "npo.nl/luister",
-            "npo.nl/start",
-            "wnl.tv"
-        ]
+        "from": ["eo.nl", "kro-ncrv.nl", "npo.nl", "npo.nl/luister", "npo.nl/start", "wnl.tv"],
+        "to": ["id.npo.nl"]
     }
 ]


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
