### PR TITLE
Add shared-credentials quirk for hejj.io and skoophr.com

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -474,6 +474,12 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "shared": [
+            "hejj.io",
+            "skoophr.com"
+        ]
+    },
+    {
         "from": [
             "heroku.com"
         ],


### PR DESCRIPTION
Adds a mutual `shared` credentials entry for `hejj.io` and `skoophr.com`.
  **Evidence the domains share a credential backend:**
  - Same company (hejj.io BV). The product is rebranding from "Hejj" (hejj.io) to "Skoop" (skoophr.com), with both domains kept live   during the migration (domain warming).
  - Verifiable link between the sites: both publish a mutual Digital Asset Links file declaring
  `delegate_permission/common.get_login_creds` for each other:
    - https://app.hejj.io/.well-known/assetlinks.json
    - https://app.skoophr.com/.well-known/assetlinks.json

    Each lists both `https://app.hejj.io` and `https://app.skoophr.com`.

  Both domains are currently active, so this is a mutual (`shared`) relationship. When `hejj.io` is eventually retired, it can move   to a one-way `from`/`to` entry with `fromDomainsAreObsoleted`.

  ### Overall Checklist
  - [x] I agree to the project's [Developer Certificate of
  Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
  - [x] The top-level JSON objects are sorted alphabetically
  - [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

  #### for shared-credentials.json
  - [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents  etc.)
  - [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts   from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il`   redirects to `accounts.google.com` for sign in.)
  - ~[ ] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.~