### PR TITLE
Add password rules for asahi-net.or.jp

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -116,6 +116,9 @@
     "artscyclery.com": {
         "password-rules": "minlength: 6; maxlength: 19;"
     },
+    "asahi-net.or.jp": {
+        "password-rules": "minlength: 6; maxlength: 15; required: lower; required: digit;"
+    },
     "astonmartinf1.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: special;"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

<img width="500" alt="asahi-net.or.jp" src="https://github.com/user-attachments/assets/4ee456a8-e598-4142-a5e3-95b89dfee769" />

半角英数字（小文字）混合6～15文字 means Must be 6–15 characters long and contain lower case and digits.