### PR TITLE
Add password rules for stayhealthy.at

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1067,6 +1067,9 @@
     "starmarket.com": {
         "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
+    "stayhealthy.at": {
+        "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
+    }
     "store.nintendo.co.uk": {
         "password-rules": "minlength: 8; maxlength: 20;"
     },
@@ -1259,4 +1262,6 @@
     "zoom.us": {
         "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
     }
+    
+
 }

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1262,6 +1262,4 @@
     "zoom.us": {
         "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
     }
-    
-
 }

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1069,7 +1069,7 @@
     },
     "stayhealthy.at": {
         "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
-    }
+    },
     "store.nintendo.co.uk": {
         "password-rules": "minlength: 8; maxlength: 20;"
     },


### PR DESCRIPTION
StayHealthy.at uses a mostly common password requirements process, however it’s not fully standard. The generated passwords work and fulfill the password requirements consistently. 

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)