### PR TITLE
Update the change password URL for craigslist

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -165,7 +165,7 @@
     "cpanel.com": "https://store.cpanel.net/my/password",
     "cpanel.net": "https://store.cpanel.net/my/password",
     "crackle.com": "https://www.crackle.com/profile",
-    "craigslist.org": "https://accounts.craigslist.org/pass",
+    "craigslist.org": "https://accounts.craigslist.org",
     "creditkarma.com": "https://www.creditkarma.com/profile/security/change-password",
     "credly.com": "https://www.credly.com/earner/settings/privacy",
     "crowdin.com": "https://accounts.crowdin.com/password/change",


### PR DESCRIPTION
https://accounts.craigslist.org/pass navigates to a 404 page when the user is not logged in already. Use https://accounts.craigslist.org instead, which is only 1 step away from the change password page, but allows the user to log in if needed.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state