### PR TITLE
Make several adjustments for automatic password upgrades on Dell, Costco, and more

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -178,7 +178,7 @@
     "darty.com": "https://www.darty.com/espace_client/donnees-personnelles/mot-de-passe/edition",
     "daum.net": "https://member.daum.net/change/password.daum",
     "deere.com": "https://account.deere.com/actmgmt/change-password",
-    "dell.com": "https://www.dell.com/identity/global/editaccount?",
+    "dell.com": "https://www.dell.com/dci/idp/dwa/editSecuritySetting",
     "delta.com": "https://www.delta.com/myprofile/security-settings",
     "deviantart.com": "https://www.deviantart.com/settings/general",
     "dickssportinggoods.com": "https://www.dickssportinggoods.com/MyAccount/AccountSettings",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -193,6 +193,14 @@
         ]
     },
     {
+        "from": [
+            "carsensor.net"
+        ],
+        "to": [
+            "point.recruit.co.jp"
+        ]
+    },
+    {
         "shared": [
             "casemates.com",
             "hammacher.com",
@@ -241,6 +249,14 @@
             "coolblue.nl",
             "coolblue.be",
             "coolblue.de"
+        ]
+    },
+    {
+        "from": [
+            "costco.ca"
+        ],
+        "to": [
+            "signin.costco.com"
         ]
     },
     {
@@ -754,6 +770,14 @@
             "going.com"
         ],
         "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
+            "sncf-connect.com"
+        ],
+        "to": [
+            "auth.monidentifiant.sncf"
+        ]
     },
     {
         "shared": [


### PR DESCRIPTION
1.  Update the password change URL for Dell (the current URL is broken)
2.  Add a shared credential from carsensor.net to point.recruit.co.jp (both are operated by Recruit Co., Ltd. (株式会社リクルート).)
3.  Add a shared credential from costco.ca to signin.costco.com
4.  Add a shared credential from sncf-connect.com to auth.monidentifiant.sncf

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.