### PR TITLE
Fixed change password url for dailymotion.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -172,7 +172,7 @@
     "crunchyroll.com": "https://www.crunchyroll.com/resetpw",
     "cvs.com": "https://www.cvs.com/my-account/profile/sign-in-and-security/edit-password",
     "dailymail.co.uk": "https://www.dailymail.co.uk/registration/profile/change-password.html",
-    "dailymotion.com": "https://www.dailymotion.com/settings",
+    "dailymotion.com": "https://www.dailymotion.com/partner/account/password",
     "dan.com": "https://dan.com/users/settings/account",
     "danawa.com": "https://auth.danawa.com/modifyMember",
     "darty.com": "https://www.darty.com/espace_client/donnees-personnelles/mot-de-passe/edition",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

Fixed dailymotion.com change password URL so it points to the actual page with change password form instead of general settings page(https://www.dailymotion.com/settings).

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state