### PR TITLE
Remove redundant all-json-valid lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,19 +25,6 @@ jobs:
           exit 1
         fi
 
-  all-json-valid:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        persist-credentials: false
-    - name: Lint Valid Json
-      run: |
-        find quirks/ -name '*.json' -print0 -maxdepth 1 | while IFS= read -r -d '' filename; do
-          echo "Validating $(basename "$filename")"
-          python -mjson.tool "$filename" > /dev/null
-        done
-
   change-password-urls:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The validate-schemas job already parses every JSON in quirks/ via ajv, so a separate parse-only check is redundant.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update