### PR TITLE
Add password rules for roblox.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -986,6 +986,9 @@
     "robinhood.com": {
         "password-rules": "minlength: 10;"
     },
+    "roblox.com": {
+    "password-rules": "minlength: 8; maxlength: 200;"
+    },
     "rogers.com": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; required: [!@#$];"
     },


### PR DESCRIPTION
Adds password rules for roblox.com
The signup page states: "Passwords must be between 8 and 200 characters long."
Tested with lowercase only (aaaaaaaa), numbers only, special characters — all accepted.
No character type restrictions enforced beyond length.

### Overall Checklist
- [x] I agree to the project's [[Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [[open pull requests](https://github.com/apple/password-manager-resources/pulls)](https://github.com/apple/password-manager-resources/pulls) for the same update
#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [[Password Rules Validation Tool](https://developer.apple.com/password-rules/)](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)