### PR TITLE
Add password rules for home.cards.citidirect.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -630,7 +630,7 @@
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: special;"
     },
     "home.cards.citidirect.com": {
-    "password-rules": "minlength: 8; maxlength: 18; required: lower, upper; required: digit; allowed: [#@$!%^&*(),~`.;:\"'?/];"
+        "password-rules": "minlength: 8; maxlength: 18; required: lower, upper; required: digit; allowed: [#@$!%^&*(),~`.;:\"'?/];"
     },
     "hotels.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: digit; required: [-~#@$%&!*_?^]; allowed: lower, upper;"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -629,6 +629,9 @@
     "hkexpress.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: special;"
     },
+    "home.cards.citidirect.com": {
+    "password-rules": "minlength: 8; maxlength: 18; required: lower, upper; required: digit; allowed: [#@$!%^&*(),~`.;:\"'?/];"
+    },
     "hotels.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: digit; required: [-~#@$%&!*_?^]; allowed: lower, upper;"
     },


### PR DESCRIPTION
Adds password rules for home.cards.citidirect.com

From issue #717. Requirements listed at the change password page
https://home.cards.citidirect.com/CommercialCard/loginsteps/changepwd:

- Should have 8 to 18 characters
- At least one letter is required
- Must contain at least a number
- Permissible special characters are #,@,$,!,%,^,&,*,(,),~,`,.,:,;,",',?,/

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update
#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)