### PR TITLE
Add password rules for patient.massciportal.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -890,6 +890,9 @@
     "parksmarter.com": {
         "password-rules": "minlength: 8; maxlength: 50; required: upper; required: digit; required: [!@#$%^&]; allowed: lower;"
     },
+    "patient.massciportal.com": {
+    "password-rules": "minlength: 12; required: upper; required: lower; required: digit; required: [!@#$%^&];"
+    },
     "pavilions.com": {
         "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -891,7 +891,7 @@
         "password-rules": "minlength: 8; maxlength: 50; required: upper; required: digit; required: [!@#$%^&]; allowed: lower;"
     },
     "patient.massciportal.com": {
-    "password-rules": "minlength: 12; required: upper; required: lower; required: digit; required: [!@#$%^&];"
+        "password-rules": "minlength: 12; required: upper; required: lower; required: digit; required: [!@#$%^&];"
     },
     "pavilions.com": {
         "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"


### PR DESCRIPTION
Adds password rules for patient.massciportal.com

From issue #570. Requirements listed at https://patient.massciportal.com/:
- At least 12 characters long
- At least one uppercase letter
- At least one lowercase letter
- At least one number
- At least one special character: !, @, #, $, %, ^, &
- Must be different from last 8 passwords

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update
#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)