### PR TITLE
Adds password rules for flyertalk.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -426,7 +426,7 @@
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [-!$%'()+,./:;=?@\\^_|~];"
     },
     "flyertalk.com": {
-        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@#_$%^&!~?*];"
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [-@#_$%^&!~?*];"
     },
     "flysas.com": {
         "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [-~!@#$%^&_+=`|(){}[:\"'<>,.?]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -425,6 +425,9 @@
     "fidelity.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [-!$%'()+,./:;=?@\\^_|~];"
     },
+    "flyertalk.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@#_$%^&!~?*];"
+    },
     "flysas.com": {
         "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [-~!@#$%^&_+=`|(){}[:\"'<>,.?]];"
     },


### PR DESCRIPTION
From issue #581. Requirements listed at https://www.flyertalk.com/:

- At least 8 characters long
- At least one lowercase letter
- At least one uppercase letter
- At least one number
- At least one special character: @ # _ $ % ^ & ! ~ ? *

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)