### PR TITLE
Adds password rules for orange.fr

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -878,6 +878,9 @@
     "online.schoolsfirstfcu.org": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [-!#$%'()*+,/=?[^_`]];"
     },
+    "orange.fr": {
+        "password-rules": "minlength: 8; required: upper; required: lower; required: digit; allowed: [-,.;+:!?_];"
+    },
     "order.wendys.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; allowed: [!#$%&()*+/=?^_{}];"
     },


### PR DESCRIPTION
From issue #479. Requirements listed at https://www.orange.fr/:

- At least 8 characters long
- At least one uppercase letter
- At least one lowercase letter
- At least one number
- Allowed special characters: , . ; + : ! ? - _

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)