### PR TITLE
Adds password rules for pinterestcareers.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -902,6 +902,9 @@
     "pilotflyingj.com": {
         "password-rules": "minlength: 7; required: digit; allowed: lower, upper;"
     },
+    "pinterestcareers.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
+    },
     "pixnet.cc": {
         "password-rules": "minlength: 4; maxlength: 16; allowed: lower, upper;"
     },


### PR DESCRIPTION
From issue #515. Requirements listed at https://www.pinterestcareers.com/:

- 8 to 16 characters long
- At least one uppercase letter
- At least one lowercase letter
- At least one number
- At least one special character

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)