### PR TITLE
Make the password validation regular expression from a meme on Reddit…

### DIFF
--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverter.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverter.js
@@ -82,7 +82,7 @@ class PatternRegexpToPasswordRulesConverter {
         }
 
         // Check if the main pattern is just . with quantifiers (allow everything)
-        const dotMatch = remaining.match(/^\.[\*\+]?(?:\{(\d+),(\d+)\})?$/);
+        const dotMatch = remaining.match(/^\.[\*\+]?(?:\{(\d+),(\d*)\})?$/);
 
         if (dotMatch) {
             const required = this.#parseLookaheads(lookaheads);
@@ -95,7 +95,7 @@ class PatternRegexpToPasswordRulesConverter {
         // Extract and consume the main character class with optional quantifier
         // This defines ALLOWED characters and optionally LENGTH constraints
         // Handle escaped ] in character class
-        const charClassMatch = remaining.match(/^\[((?:[^\]\\]|\\.)*)\](?:\{(\d+),(\d+)\})?$/);
+        const charClassMatch = remaining.match(/^\[((?:[^\]\\]|\\.)*)\](?:\{(\d+),(\d*)\})?$/);
 
         if (!charClassMatch) {
             console.warn("PatternRegexpToPasswordRulesConverter: Unable to parse regexp pattern - main character class not found or has unexpected format");
@@ -369,18 +369,28 @@ class PatternRegexpToPasswordRulesConverter {
 
     /**
      * Extract min/max length from match
+     * Supports both closed quantifiers like {8,20} and open-ended ones like {8,}
      * @private
      */
     static #extractLength(match, minGroup, maxGroup) {
-        if (match[minGroup] && match[maxGroup]) {
-            const min = parseInt(match[minGroup], 10);
-            const max = parseInt(match[maxGroup], 10);
-            if (!isNaN(min) && !isNaN(max)) {
-                return { min: min, max: max };
+        let min = null;
+        let max = null;
+
+        if (match[minGroup]) {
+            const parsed = parseInt(match[minGroup], 10);
+            if (!isNaN(parsed)) {
+                min = parsed;
             }
         }
 
-        return { min: null, max: null };
+        if (match[maxGroup]) {
+            const parsed = parseInt(match[maxGroup], 10);
+            if (!isNaN(parsed)) {
+                max = parsed;
+            }
+        }
+
+        return { min: min, max: max };
     }
 
     /**

--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
@@ -20,6 +20,7 @@ class PatternRegexpToPasswordRulesConverterTest {
         this.testSimplePatterns();
         this.testBasicConversion();
         this.testOptionalLength();
+        this.testOpenEndedQuantifier();
         this.testHyphenHandling();
         this.testSpecialCharacterHandling();
         this.testCharacterClassNormalization();
@@ -126,6 +127,39 @@ class PatternRegexpToPasswordRulesConverterTest {
                 name: "Pattern with lookaheads but no length",
                 regexp: "^(?=.*[A-Z])[A-Z!@#]$",
                 expected: "required: upper; allowed: [!@#];"
+            }
+        ];
+
+        testCases.forEach(({ name, regexp, expected }) => {
+            const result = PatternRegexpToPasswordRulesConverter.convert(regexp);
+            const passed = result === expected;
+
+            console.log(`Test: ${name}`);
+            console.log(`Expected: ${expected}`);
+            console.log(`Got:      ${result}`);
+            console.log(`Status:   ${passed ? '✅ PASS' : '❌ FAIL'}\n`);
+            this.recordResult(passed);
+        });
+    }
+
+    testOpenEndedQuantifier() {
+        console.log("=== Open-Ended Quantifier Tests ===\n");
+
+        const testCases = [
+            {
+                name: "Open-ended quantifier on character class",
+                regexp: "^(?=.*[0-9])[a-zA-Z0-9]{8,}$",
+                expected: "required: digit; allowed: lower, upper; minlength: 8;"
+            },
+            {
+                name: "Open-ended quantifier with multiple lookaheads and special chars",
+                regexp: "(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}",
+                expected: "required: lower; required: upper; required: digit; required: [@$!%*?&]; minlength: 8;"
+            },
+            {
+                name: "Open-ended quantifier on dot pattern",
+                regexp: "^(?=.*[0-9])(?=.*[a-z]).{8,}$",
+                expected: "required: digit; required: lower; minlength: 8;"
             }
         ];
 


### PR DESCRIPTION
… convertible into passwordRules

https://www.reddit.com/r/ProgrammerHumor/comments/1ueo25g/postpasskeymigrationblues/

To make this one work, we need to support specifying an open-ended qualifier. That is, a min length without a max length.

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update