### PR TITLE
Add Tokyo Tech Portal shared credentials

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -566,6 +566,15 @@
     },
     {
         "from": [
+            "kyomu0.gakumu.titech.ac.jp",
+            "portal.titech.ac.jp"
+        ],
+        "to": [
+            "portal.nap.gsic.titech.ac.jp"
+        ]
+    },
+    {
+        "from": [
             "letsdeel.com"
         ],
         "to": [


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

## Summary

Add a shared credentials entry for Tokyo Tech Portal domains that redirect or link users to the same first-factor account/password authentication flow.

Domains added:

- `portal.nap.gsic.titech.ac.jp`
- `portal.titech.ac.jp`
- `kyomu0.gakumu.titech.ac.jp`

## Evidence

- `portal.titech.ac.jp` is the public Tokyo Tech Portal / Science & Engineering portal and links users to matrix/OTP authentication. The page also identifies `portal.nap.gsic.titech.ac.jp` as part of the portal authentication flow.
- `portal.nap.gsic.titech.ac.jp/GetAccess/Login?Template=userpass_key&AUTHMETHOD=UserPassword` serves the first-factor "Please input your account & password" login page.
- Tokyo Tech official student guidance documents describe accessing the Web System for Students and Faculty through Tokyo Tech Portal and reference `kyomu0.gakumu.titech.ac.jp` for that system.

## Notes

This entry is intentionally limited to the first-factor account/password domains. Later matrix-code, OTP, or soft-token authentication steps are not represented as password-manager credentials.

The login form currently uses `name="usr_name"` and `name="usr_password"` with `autocomplete="off"`, so this shared-credentials entry addresses domain association. It does not attempt to add a form-field classification quirk, which does not appear to be represented by the repository's current public data schemas.

## Validation

- `npx.cmd --yes ajv-cli validate -s quirks\schemas\shared-credentials-schema.json -d quirks\shared-credentials.json --spec=draft2020`
- Local checks for JSON parse, shared-credentials sort order, entry shape, and duplicate domains across `shared-credentials.json` and `shared-credentials-historical.json`.
