### PR TITLE
Add password rules for mysmartmove.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -854,6 +854,9 @@
     "mysedgwick.com": {
         "password-rules": "minlength: 8; maxlength: 16; allowed: lower; required: upper; required: digit; required: [@#$%^&+=!];"
     },
+    "mysmartmove.com": {
+        "password-rules": "minlength: 9; maxlength: 15; allowed: lower; required: upper; required: [!@#$%^&*()];"
+    },
     "mysubaru.com": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; allowed: [!#$%()*+,./:;=?@\\^`~];"
     },


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

Requires a minimum length of 9, maximum of 15, a special character, and an uppercase letter.
<img width="476" height="353" alt="2026-07-04 at 08 15 12@2x" src="https://github.com/user-attachments/assets/cfe22d20-5d8e-47e7-9b07-979cdc51f238" />
<img width="476" height="353" alt="2026-07-04 at 08 14 46@2x" src="https://github.com/user-attachments/assets/620f1473-d277-4f09-88be-0cb5b3e3cc73" />


### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)