### PR TITLE
Add Bowser to web browser extension distribution information

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -1303,6 +1303,24 @@
             "supported_store_identifiers": [
                 1
             ]
+        },
+        {
+            "long_name": "Bowser",
+            "short_name": "Bowser",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "me.bnfy.bowser",
+                    "code_signing_identifier": "me.bnfy.bowser",
+                    "code_signing_team_identifier": "XYGUCY4498",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Bowser/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1
+            ]
         }
     ]
 }


### PR DESCRIPTION
This adds **Bowser**, a minimal Chromium-based (Electron) browser for macOS, to `web-browser-extension-distribution-information.json` so that the iCloud Passwords browser extension can communicate with its native messaging host when running in Bowser.

- **Bundle identifier / code signing identifier:** `me.bnfy.bowser`
- **Code signing team identifier:** `XYGUCY4498` (Developer ID–signed and notarized)
- **Extensions install path:** `Application Support/Bowser/Extensions` (same Chromium-extension layout as other Electron-based browsers in this list, e.g. Polypane)

Verification of the shipping app's signature:

```
$ codesign -dv /Applications/Bowser.app
Identifier=me.bnfy.bowser
TeamIdentifier=XYGUCY4498
```

Thanks for considering!