### PR TITLE
Add password rules for hdfc.bank.in

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -479,6 +479,9 @@
     "hawaiianairlines.com": {
         "password-rules": "maxlength: 16;"
     },
+    "hdfc.bank.in": {
+        "password-rules": "minlength: 8; maxlength: 15; required: digit; required: upper, lower; allowed: [@&:|.^~#_$!)?];"
+    },
     "hertz-japan.com": {
         "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower; required: upper; required: digit; required: [#$%^&!@];"
     },


### PR DESCRIPTION
#### Summary
- Adds a `password-rules` entry for `hdfc.bank.in`: minlength 8, maxlength 15, requires a digit and both upper/lower case, allows a specific set of special characters: @ & : | . ^ ~ # _ $ ! ) ?

#### Screenshot
<img width="877" height="967" alt="Screenshot 2026-07-05 at 10 15 36 AM" src="https://github.com/user-attachments/assets/aa8a3309-cece-4897-8ee1-76e57d3f2de0" />

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)