### PR TITLE
Add change-password URL for amtrak.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -58,6 +58,7 @@
     "amazonaws.com": "https://console.aws.amazon.com/iam/home#/security_credentials",
     "amctheatres.com": "https://www.amctheatres.com/amcstubs/account",
     "americanexpress.com": "https://www.americanexpress.com/en-us/account/password/manage",
+    "amtrak.com": "https://www.amtrak.com/guestrewards/account-overview/profile",
     "ana.co.jp": "https://cam.ana.co.jp/psz/us/amc_us.jsp?index=105",
     "anatel.gov.br": "https://apps.anatel.gov.br/AnatelConsumidor/ConsumidorEditar.aspx",
     "ancestry.com": "https://www.ancestry.com/account/security/password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state