### PR TITLE
Update Expedia change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -218,7 +218,7 @@
     "etsy.com": "https://www.etsy.com/your/account",
     "eventbrite.com": "https://www.eventbrite.com/account-settings/password",
     "evite.com": "https://www.evite.com/settings/password",
-    "expedia.com": "https://www.expedia.com/user/forgotpassword",
+    "expedia.com": "https://www.expedia.com/account/settings",
     "experian.com": "https://usa.experian.com/member/ngx-profile/account-info",
     "facebook.com": "https://accountscenter.facebook.com/password_and_security/password/change",
     "familysearch.org": "https://www.familysearch.org/identity/settings/account",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state