### PR TITLE
Add password rules for sevasindhuservices.karnataka.gov.in

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1058,6 +1058,9 @@
     "servizioelettriconazionale.it": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [!#$%&*?@^_~];"
     },
+    "sevasindhuservices.karnataka.gov.in": {
+        "password-rules": "minlength: 9; required: lower; required: upper; required: digit; required: [!@#$%^&*];"
+    },
     "sfwater.org": {
         "password-rules": "minlength: 10; maxlength: 30; required: digit; allowed: lower, upper, [!@#$%*()_+^}{:;?.];"
     },


### PR DESCRIPTION
## Website requirements

[sevasindhuservices.karnataka.gov.in](https://sevasindhuservices.karnataka.gov.in/) states the following password policy on its registration form:

> Note: Password should be at least '9' characters with at least one special character(!@#$%^&*), one numeric, one small case and one upper case letter (i.e ADmin@357)

This translates to:

```
minlength: 9; required: lower; required: upper; required: digit; required: [!@#$%^&*];
```

## Testing

Generated passwords were tested directly against the live registration form.

### Accepted

- ✅ `yxCx9*1yWtd2`
<img width="836" height="526" alt="image" src="https://github.com/user-attachments/assets/711c8cf0-62d0-4273-8e7e-e7501db238fe" />

- ✅ `vnGNjB0V9I&@`
<img width="873" height="514" alt="image" src="https://github.com/user-attachments/assets/6f000559-8685-42e1-8b55-f06b713a35ae" />

- ✅ `zu4^5eZxfnp*`
<img width="743" height="496" alt="image" src="https://github.com/user-attachments/assets/65ff539b-72f7-425d-9581-1c5080b411e1" />

### Rejected

Some test cases that fail.

- ❌ `zu45eZxfnp` — no special character
<img width="735" height="506" alt="image" src="https://github.com/user-attachments/assets/5cfb009e-bfa1-4599-997d-fc015502dc10" />

- ❌ `zu45eZxfn_` — special character present, but `_` is not in the site's allowed set `!@#$%^&*`
<img width="734" height="513" alt="image" src="https://github.com/user-attachments/assets/febca5c1-19ab-42e9-9af8-9792c00db2f7" />

- ❌ `zu45ezxfn$` — no uppercase letter
<img width="727" height="496" alt="image" src="https://github.com/user-attachments/assets/fd91ac2c-a8ee-4b1b-9cb7-beb7b46e1b96" />

- ❌ `ZU45EZXFN$` — no lowercase letter
<img width="742" height="500" alt="image" src="https://github.com/user-attachments/assets/8f845b5f-9392-4b07-88c0-c518fd76101f" />

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
