### PR TITLE
Unescape special characters in converter lookaheads

### DIFF
--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverter.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverter.js
@@ -219,6 +219,9 @@ class PatternRegexpToPasswordRulesConverter {
             // Remove stray single letters/digits left from range edges
             remaining = remaining.replace(/[a-zA-Z0-9]/g, "");
 
+            // Unescape regexp escape sequences after expanding shorthand classes.
+            remaining = remaining.replace(/\\(.)/g, "$1");
+
             if (types.length > 0 && remaining.length === 0) {
                 // Pure range-based, possibly combined (e.g., 'upper, lower')
                 required.push(types.join(", "));

--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
@@ -244,6 +244,17 @@ class PatternRegexpToPasswordRulesConverterTest {
             console.log(`Status:   ${passed ? '✅ PASS' : '❌ FAIL'}\n`);
             this.recordResult(passed);
         });
+
+        const escapedRegexp = "^(?=.*[\\!\\@])[a-zA-Z0-9\\!\\@]{8,}$";
+        const escapedExpected = "required: [!@]; allowed: lower, upper, digit; minlength: 8;";
+        const escapedResult = PatternRegexpToPasswordRulesConverter.convert(escapedRegexp);
+        const escapedPassed = escapedResult === escapedExpected;
+
+        console.log("Test: Escaped special chars in lookahead");
+        console.log(`Expected: ${escapedExpected}`);
+        console.log(`Got:      ${escapedResult}`);
+        console.log(`Status:   ${escapedPassed ? '✅ PASS' : '❌ FAIL'}\n`);
+        this.recordResult(escapedPassed);
     }
 
     testCharacterClassNormalization() {


### PR DESCRIPTION
Escaped special characters in a regexp lookahead produce invalid and duplicated Password Rules output.

### Overall Checklist

- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically (N/A — no JSON changes)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

Fixes #1159.

## Reproduction

- Pattern: `^(?=.*[\!\@])[a-zA-Z0-9\!\@]{8,}$`
- Expected: `required: [!@]; allowed: lower, upper, digit; minlength: 8;`
- Actual: `required: [\!\@]; allowed: lower, upper, digit, [!@]; minlength: 8;`

## Change

- Unescape regexp-escaped characters in the lookahead path after shorthand expansion and stray-letter removal, immediately before the required character class is normalized — mirroring the existing unescape in the allowed-character path.
- Add an exact-output regression test for escaped special characters in a lookahead.

This also allows the existing required/allowed deduplication to recognize that `[!@]` is already required.

## Verification

Ran `sh tools/PatternRegexpToPasswordRulesConverter/run-tests.sh`; all converter tests pass, including the new regression test.

## Actual screenshots

| Before (`91312a9`) | After (`1b5703f`) |
| --- | --- |
| <img width="1331" height="768" alt="Before: terminal reproduction showing escaped lookahead characters retained in the generated rules" src="https://github.com/user-attachments/assets/51004240-2062-41c3-a0e3-9e6e08200dd6" /> | <img width="1331" height="768" alt="After: terminal reproduction showing normalized required characters and all 50 tests passing" src="https://github.com/user-attachments/assets/2cd9b8f5-b029-4e9f-a3ef-d3b409f283a2" /> |

```text
Test: Escaped special chars in lookahead
Expected: required: [!@]; allowed: lower, upper, digit; minlength: 8;
Got:      required: [!@]; allowed: lower, upper, digit; minlength: 8;
Status:   ✅ PASS

All 50 tests passed.
```
