### PR TITLE
Reject unsupported partial ranges in regexp conversion

### DIFF
--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverter.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverter.js
@@ -104,6 +104,12 @@ class PatternRegexpToPasswordRulesConverter {
             return null;
         }
 
+        if (this.#containsUnsupportedAlphanumericRange(charClassMatch[1])) {
+            console.warn("PatternRegexpToPasswordRulesConverter: Main character class contains an unsupported alphanumeric range");
+            console.warn("Pattern:", regexp);
+            return null;
+        }
+
         // Parse the validated components
         const required = this.#parseLookaheads(lookaheads);
         const allowed = this.#parseCharacterClassFromMatch(charClassMatch, required);
@@ -183,8 +189,39 @@ class PatternRegexpToPasswordRulesConverter {
                     return false;
                 }
             }
+
+            if (this.#containsUnsupportedAlphanumericRange(lookahead)) {
+                return false;
+            }
         }
         return true;
+    }
+
+    /**
+     * Check for alphanumeric ranges the converter cannot represent exactly
+     * @private
+     */
+    static #containsUnsupportedAlphanumericRange(charClass) {
+        const supportedRanges = new Set(["a-z", "A-Z", "0-9"]);
+        const isAlphanumeric = (character) => /[a-zA-Z0-9]/.test(character);
+
+        for (let index = 0; index < charClass.length; ++index) {
+            if (charClass[index] === "\\" && index + 1 < charClass.length) {
+                ++index;
+                continue;
+            }
+
+            const range = charClass.substring(index, index + 3);
+            if (range.length === 3 && range[1] === "-" && isAlphanumeric(range[0]) && isAlphanumeric(range[2])) {
+                if (!supportedRanges.has(range)) {
+                    return true;
+                }
+
+                index += 2;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
@@ -198,6 +198,11 @@ class PatternRegexpToPasswordRulesConverterTest {
                 name: "Hyphen at beginning (should stay at front)",
                 regexp: "^(?=.*[0-9])[a-zA-Z0-9-!@#$]{8,20}$",
                 expected: "required: digit; allowed: lower, upper, [-!@#$]; minlength: 8; maxlength: 20;"
+            },
+            {
+                name: "Full ranges beside a literal hyphen",
+                regexp: "^[a-zxA-Z-y]{8,}$",
+                expected: "allowed: lower, upper, [-]; minlength: 8;"
             }
         ];
 
@@ -470,6 +475,16 @@ class PatternRegexpToPasswordRulesConverterTest {
             {
                 name: "Regex with quantifier on lookahead",
                 regexp: "^(?=.*[0-9]){2}[a-z0-9]{8,20}$",
+                shouldBeNull: true
+            },
+            {
+                name: "Partial range in lookahead",
+                regexp: "^(?=.*[a-y])[a-zA-Z0-9]{8,}$",
+                shouldBeNull: true
+            },
+            {
+                name: "Partial range in main character class",
+                regexp: "^[a-z2-9]{8,}$",
                 shouldBeNull: true
             }
         ];


### PR DESCRIPTION
Partial alphanumeric ranges can be silently converted into rules that require a literal hyphen.

### Overall Checklist

- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically (N/A — no JSON changes)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

Fixes #1161. This change is independent of #1160.

## Reproduction

Required-character path:

- Pattern: `^(?=.*[a-y])[a-zA-Z0-9]{8,}$`
- Expected: `null` because the partial range is unsupported.
- Actual: `required: [-]; allowed: lower, upper, digit; minlength: 8;`

Allowed-character path:

- Pattern: `^[a-z2-9]{8,}$`
- Expected: `null` because the partial range is unsupported.
- Actual: `allowed: lower, [-]; minlength: 8;`

## Change

- Validate alphanumeric ranges before converting character classes: any `X-Y` range with alphanumeric endpoints must be exactly `a-z`, `A-Z`, or `0-9`.
- Reject unsupported partial ranges in both lookaheads and the main character class, returning `null` with a `console.warn`, consistent with the converter's existing explicit rejection paths. Out-of-order ranges like `a-Z` (a `SyntaxError` in a real regexp engine) are rejected as a side effect.
- Keep the existing literal-character treatment for ranges with non-alphanumeric endpoints such as `!-?`.
- Protect `[a-zxA-Z-y]` as a must-still-convert case so validation does not invent a phantom `x-y` range after stripping supported ranges.
- Add regression coverage for both rejection paths and the must-still-convert path.

Rejecting the pattern avoids silently broadening its meaning or introducing a literal-hyphen requirement.

## Verification

Ran `sh tools/PatternRegexpToPasswordRulesConverter/run-tests.sh`; all converter tests pass, including both partial-range regressions and the full-range/literal-hyphen guard.

## Actual screenshots

| Before (`91312a9`) | After (`b5d48ad`) |
| --- | --- |
| <img width="1331" height="768" alt="Before: terminal reproduction showing partial ranges converted into literal-hyphen rules" src="https://github.com/user-attachments/assets/3d97a1b1-0f16-4b12-abc0-653d677dd44e" /> | <img width="1331" height="768" alt="After: terminal reproduction showing partial ranges rejected, the guard preserved, and all 52 tests passing" src="https://github.com/user-attachments/assets/8f969b19-12f5-4a85-89ef-56e88577bdab" /> |

```text
Test: Full ranges beside a literal hyphen
Expected: allowed: lower, upper, [-]; minlength: 8;
Got:      allowed: lower, upper, [-]; minlength: 8;
Status:   ✅ PASS

Test: Partial range in lookahead
Result:   null (rejected)
Status:   ✅ PASS

Test: Partial range in main character class
Result:   null (rejected)
Status:   ✅ PASS

All 52 tests passed.
```
