### PR TITLE
Fix password-rules path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A rule that should only be applied to the exact domain stated as a key should ha
 
 ### Password Rules Language Parser
 
-An implementation of a parser for the Password Rules language that's written in JavaScript can be found in [`tools/PasswordRulesParser.js`](tools/PasswordRulesParser.js). It can be used as a reference implementation, interpreted in build systems to convert `data/password-rules.json` to an application-specific format, or interpreted at application runtime wherever it's possible to execute JavaScript (e.g. using the JavaScriptCore framework on Apple platforms).
+An implementation of a parser for the Password Rules language that's written in JavaScript can be found in [`tools/PasswordRulesParser.js`](tools/PasswordRulesParser.js). It can be used as a reference implementation, interpreted in build systems to convert `quirks/password-rules.json` to an application-specific format, or interpreted at application runtime wherever it's possible to execute JavaScript (e.g. using the JavaScriptCore framework on Apple platforms).
 
 A [third-party parser implementation](https://github.com/1Password/password-rules-parser) that's written in Rust is also available.
 


### PR DESCRIPTION
The parser documentation tells integrators to read `data/password-rules.json`, but the repository stores that data at `quirks/password-rules.json`.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically (N/A — no JSON changes)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

## Reproduction

In the Password Rules Language Parser section:

- Documented path: `data/password-rules.json`
- Expected path: `quirks/password-rules.json`
- Actual repository state: `data/password-rules.json` does not exist; `quirks/password-rules.json` does.
- Provenance: #3 (`75d9398`) updated the README's linked `data/` references to `quirks/` but missed this occurrence because it is formatted as inline code rather than a link. It was the last remaining `data/` path in the Markdown documentation.

## Change

Update the parser documentation to reference `quirks/password-rules.json`.

## Verification

Verified against upstream `38d68da` and fixed revision `91846b1`.

```text
Before:
data/password-rules.json

After:
quirks/password-rules.json
data/password-rules.json: missing
quirks/password-rules.json: present
Tracked Markdown data/ references: none
git diff --check: passed
```
