### PR TITLE
Reject blank password rules in schema

### DIFF
--- a/quirks/schemas/password-rules-schema.json
+++ b/quirks/schemas/password-rules-schema.json
@@ -5,7 +5,8 @@
     "type": "object",
     "properties": {
       "password-rules": {
-        "type": "string"
+        "type": "string",
+        "pattern": "\\S"
       }
     },
     "additionalProperties": false,


### PR DESCRIPTION
Blank password-rule strings pass schema validation, and the parser then silently interprets them as `allowed: ascii-printable`... so an entry claiming the website accepts any ASCII-printable password.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically (N/A — schema change only; no quirk data changes)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

## Reproduction

Given an entry whose `password-rules` value is empty or contains only whitespace:

- Expected: schema validation rejects the entry.
- Actual: schema validation succeeds, permitting an entry with no meaningful rule content.
- Consequence: `tools/PasswordRulesParser.js` parses both `""` and `"   "` to `allowed: ascii-printable`, so a blank entry silently claims the website accepts any ASCII-printable password.
- CI impact: a blank entry passes CI today. 
- - The `validate-schemas` job permits it because the current schema does, 
- - and the `password-rules` parse lint accepts it because a blank string parses without error.

A rule containing non-whitespace content, including one with surrounding formatting whitespace, should remain valid.

---

## Change

Require every `password-rules` string to contain at least one non-whitespace character.

Using a `\S` pattern rejects both empty and whitespace-only values while preserving rules with leading or trailing formatting whitespace.

No existing entry is affected. The repository's existing `validate-schemas` CI job will enforce the new constraint automatically.

## Verification

Verified against upstream `38d68da` and fixed revision `94300e2`. All 429 existing `password-rules` entries contain non-whitespace content.

```text
/private/tmp/pr3-empty.json invalid
data/example.com/password-rules must match pattern "\S"
EXPECTED: /private/tmp/pr3-empty.json was rejected
/private/tmp/pr3-whitespace.json invalid
data/example.com/password-rules must match pattern "\S"
EXPECTED: /private/tmp/pr3-whitespace.json was rejected
/private/tmp/pr3-meaningful.json valid
EXPECTED: /private/tmp/pr3-meaningful.json was accepted

quirks/websites-that-append-2fa-to-password.json valid
quirks/change-password-URLs.json valid
quirks/apple-appIDs-to-domains-shared-credentials.json valid
quirks/web-browser-extension-distribution-information.json valid
quirks/shared-credentials.json valid
quirks/password-rules.json valid
quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json valid
quirks/shared-credentials-historical.json valid
```

## Actual screenshots

| Before (`38d68da`) | After (`94300e2`) |
| --- | --- |
| ![Blank password rules accepted before the schema change](https://raw.githubusercontent.com/Kevinjohn/password-manager-resources/5302d7bcd8d4abec0d7e2744b191d8ce225a9c0b/.github/pr-evidence/blank-password-rules-before.jpg) | ![Blank password rules rejected after the schema change](https://raw.githubusercontent.com/Kevinjohn/password-manager-resources/5302d7bcd8d4abec0d7e2744b191d8ce225a9c0b/.github/pr-evidence/blank-password-rules-after.jpg) |
