### PR TITLE
Report missing quirk schemas clearly

### DIFF
--- a/tools/validate-json-schemas.sh
+++ b/tools/validate-json-schemas.sh
@@ -12,6 +12,10 @@ fi
 # Finds all JSON files in the quirks directory and validates them against the corresponding schema.
 find quirks -name '*.json' -print0 -maxdepth 1 | while IFS= read -r -d '' filename; do
     schema="quirks/schemas/$(basename "$filename" .json)-schema.json"
+    if [ ! -f "$schema" ]; then
+        echo "No schema found for $filename. Expected $schema." >&2
+        exit 1
+    fi
     echo "Validating $filename against $schema"
     ajv -s "$schema" -d "$filename" --spec=draft2020
 done


### PR DESCRIPTION
Adding a quirk file, without its matching schema, produces an AJV file error.
I believe that it should identify the schema contributors need to add.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically (N/A — no JSON changes)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

## Reproduction

Given a temporary top-level quirk file without its conventionally named schema:

- Quirk: `quirks/missing-schema-example.json`
- Expected schema: `quirks/schemas/missing-schema-example-schema.json`
- Expected: validation identifies the missing schema and its expected path.
- Actual: the script delegates the missing path to AJV, which reports an implementation-level loading error and require stack.

## Change

Check that each derived schema path exists before invoking AJV.

If it does not, print the quirk filename and expected schema path to standard error and exit nonzero. Existing AJV invocation and successful-path behavior remain unchanged.

All eight current top-level quirk files already have matching schemas, so no existing data is affected.

## Verification

- Confirmed a quirk file without its schema exits 1 with the new actionable message.
- Confirmed the message names both the quirk file and expected schema path.
- Removed the temporary reproduction fixture.
- Ran `tools/validate-json-schemas.sh`; all eight existing quirk files continue to validate.
- Ran `bash -n tools/validate-json-schemas.sh` successfully.
- Ran `git diff --check` successfully.

## Actual screenshots

| Before (`a742917`) | After (`d5e79ad`) |
| --- | --- |
| ![AJV implementation-level error before the missing-schema guard](https://raw.githubusercontent.com/Kevinjohn/password-manager-resources/ba590a2ad034bcab695f72a292c2d3577061b72d/.github/pr-evidence/missing-schema-before.jpg) | ![Actionable missing-schema error after the guard](https://raw.githubusercontent.com/Kevinjohn/password-manager-resources/ba590a2ad034bcab695f72a292c2d3577061b72d/.github/pr-evidence/missing-schema-after.jpg) |

```text
Before (a742917):
Validating quirks/missing-schema-example.json against quirks/schemas/missing-schema-example-schema.json
error: Cannot find schema '<repo>/quirks/schemas/missing-schema-example-schema.json'
Require stack:
...
Exit status: 2

After (d5e79ad):
No schema found for quirks/missing-schema-example.json. Expected quirks/schemas/missing-schema-example-schema.json.
Exit status: 1

Repository validation:
quirks/websites-that-append-2fa-to-password.json valid
quirks/change-password-URLs.json valid
quirks/apple-appIDs-to-domains-shared-credentials.json valid
quirks/web-browser-extension-distribution-information.json valid
quirks/shared-credentials.json valid
quirks/password-rules.json valid
quirks/websites-that-ask-for-credentials-for-other-services-when-embedded-as-third-party.json valid
quirks/shared-credentials-historical.json valid
```
