### PR TITLE
Add a password rule for qualtrics.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -983,6 +983,9 @@
     "qdosstatusreview.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&@^];"
     },
+    "qualtrics.com": {
+        "password-rules": "minlength: 8; required: [!@#$%]; allowed: lower, upper, digit;"
+    },
     "questdiagnostics.com": {
         "password-rules": "minlength: 8; maxlength: 30; required: upper, lower; required: digit, [!#$%&()*+<>?@^_~];"
     },


### PR DESCRIPTION
If you type fewer than eight characters, you get an error. If you don't include the right special character, you get:
Password must contain one or more special characters (e.g. ! @ # $ %)
    
Lower, upper, and digit are all allowed via testing.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)