### PR TITLE
Add shared credentials for The Collecting Group (collecting.com, collectingcars.com, watchcollecting.com)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -254,6 +254,13 @@
     },
     {
         "shared": [
+            "collecting.com",
+            "collectingcars.com",
+            "watchcollecting.com"
+        ]
+    },
+    {
+        "shared": [
             "coolblue.nl",
             "coolblue.be",
             "coolblue.de"


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)

## Summary

Adds a shared-credentials entry grouping the three domains operated by The Collecting Group Ltd:

- [collecting.com](https://collecting.com)
- [collectingcars.com](https://collectingcars.com)
- [watchcollecting.com](https://watchcollecting.com)

These sites share a single account/credential backend. The group is consolidating its brands onto collecting.com, and credentials saved on the existing brand domains should be suggested across the group.

## Evidence

- WHOIS for collecting.com lists **Registrant Organization: The Collecting Group Ltd**.
- The collecting.com homepage links directly to both collectingcars.com and watchcollecting.com as its brands (they are the only external brand links on the page).
- collectingcars.com and watchcollecting.com each serve their own sign-in pages on their own domains (no cross-domain redirect to a central auth host), and accounts are accepted across the group's sites.
- I work for The Collecting Group — this request is part of our domain-consolidation project, and I can confirm the sites share a credential backend. collecting.com is the consolidation target and serves the group's unified login as part of this migration.

## Validation

`quirks/shared-credentials.json` validates against `quirks/schemas/shared-credentials-schema.json` via `ajv-cli` (`--spec=draft2020`), and the entry is inserted in alphabetical order (between `cleanshot.cloud` and `coolblue.nl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
