### PR TITLE
Allow exact-domain-match-only in password-rules schema

### DIFF
--- a/quirks/schemas/password-rules-schema.json
+++ b/quirks/schemas/password-rules-schema.json
@@ -6,6 +6,9 @@
     "properties": {
       "password-rules": {
         "type": "string"
+      },
+      "exact-domain-match-only": {
+        "type": "boolean"
       }
     },
     "additionalProperties": false,


### PR DESCRIPTION
## Summary
- Aligns `quirks/schemas/password-rules-schema.json` with the README: optional `exact-domain-match-only` boolean on password-rule entries.
- Per maintainer guidance on #1165, keep the documented flag even though no current entries use it yet.

## Test plan
- [x] `ajv-cli -s quirks/schemas/password-rules-schema.json -d quirks/password-rules.json --spec=draft2020` → valid
- [x] Fixture with `exact-domain-match-only: true` → valid
- [x] Fixture with an unknown extra property → still invalid

Fixes #1165

Made with [Cursor](https://cursor.com)