### PR TITLE
Add shared credentials for Bluesky (bsky.app, bsky.social)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -196,6 +196,12 @@
     },
     {
         "shared": [
+            "bsky.app",
+            "bsky.social"
+        ]
+    },
+    {
+        "shared": [
             "candyrect.com",
             "nekochat.cn"
         ]


### PR DESCRIPTION
## Summary
- Adds a shared-credentials entry for `bsky.app` and `bsky.social` (fixes #968).
- Bluesky’s web client is at `bsky.app`; AT Proto app logins use `bsky.social`. The `bsky.app` homepage links to `bsky.social` and documents the same Bluesky Social identity system.

## Evidence
- https://bsky.app HTML includes `<link rel="preconnect" href="https://bsky.social">` and copy linking to bsky.social / atproto.com
- Issue description: signing into Bluesky happens at bsky.app; signing into other AT Proto apps happens at bsky.social

## Test plan
- [x] `ajv-cli` validates `quirks/shared-credentials.json` against the schema
- [ ] Maintainer review of shared-backend relationship