### PR TITLE
Add shared credentials for SoftBank povo (povo.jp)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -759,6 +759,12 @@
     },
     {
         "shared": [
+            "pjp-povo.jp.auth0.com",
+            "povo.jp"
+        ]
+    },
+    {
+        "shared": [
             "postnl.nl",
             "postnl.be"
         ]


### PR DESCRIPTION
## Summary
- Adds a shared-credentials entry for `povo.jp` and `pjp-povo.jp.auth0.com` (fixes #964).
- SoftBank’s povo service authenticates through the Auth0 tenant `pjp-povo.jp.auth0.com`.

## Evidence
- Issue #964 documents the shared-credential relationship.
- `povo.jp` is SoftBank’s povo consumer site; login is hosted on the Auth0 tenant named for povo (`pjp-povo.jp.auth0.com`).

## Test plan
- [x] `websites-shared-credentials-sort-order.rb` passes
- [ ] Maintainer review of shared-backend relationship