### PR TITLE
Add shared credentials for JR West Wester / DWmall

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -362,6 +362,12 @@
     },
     {
         "shared": [
+            "dwmall.westjr.co.jp",
+            "wester.jr-odekake.net"
+        ]
+    },
+    {
+        "shared": [
             "e621.net",
             "e926.net"
         ]


### PR DESCRIPTION
## Summary
- Adds a shared-credentials entry for `dwmall.westjr.co.jp` and `wester.jr-odekake.net` (fixes #965).

## Evidence
- Issue #965 documents the shared-credential relationship.
- `dwmall.westjr.co.jp` is JR West’s DWmall storefront; its CSP references `auth.westjr.co.jp` and `jr-odekake.net` assets, aligning with the Wester (`wester.jr-odekake.net`) West JR travel account surface.

## Test plan
- [x] `websites-shared-credentials-sort-order.rb` passes
- [ ] Maintainer review of shared-backend relationship