### PR TITLE
Add shared credentials for Tokai Station Point

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -879,6 +879,12 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "shared": [
+            "tspoint.jr-central.co.jp",
+            "tspoint.jp"
+        ]
+    },
+    {
         "from": [
             "tvnow.de",
             "tvnow.at",


### PR DESCRIPTION
## Summary
- Adds a shared-credentials entry for `tspoint.jp` and `tspoint.jr-central.co.jp` (fixes #963).

## Evidence
- Issue #963 documents the shared-credential relationship for JR Central’s Tokai Station Point program.

## Test plan
- [x] `websites-shared-credentials-sort-order.rb` passes
- [ ] Maintainer review