### PR TITLE
Add shared credentials for Club Animate / Animate Bookstore

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -159,6 +159,12 @@
     },
     {
         "shared": [
+            "animatebookstore.com",
+            "club-animate.jp"
+        ]
+    },
+    {
+        "shared": [
             "anthem.com",
             "sydneyhealth.com"
         ]


### PR DESCRIPTION
## Summary
- Adds a shared-credentials entry for `animatebookstore.com` and `club-animate.jp` (fixes #961).

## Evidence
- Issue #961 documents the shared-credential relationship for Animate’s Club Animate / bookstore surfaces.

## Test plan
- [x] `websites-shared-credentials-sort-order.rb` passes
- [ ] Maintainer review