### PR TITLE
Add shared credentials for Comici / Champion Cross

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -230,6 +230,13 @@
     },
     {
         "shared": [
+            "championcross.jp",
+            "comici.jp",
+            "youngchampion.jp"
+        ]
+    },
+    {
+        "shared": [
             "chat.com",
             "chatgpt.com",
             "openai.com"


### PR DESCRIPTION
## Summary
- Adds a shared-credentials entry for `championcross.jp`, `comici.jp`, and `youngchampion.jp` (fixes #962).

## Evidence
- Issue #962 documents that these domains share credentials.

## Test plan
- [x] Diff limited to the new entry only
- [x] `websites-shared-credentials-sort-order.rb` passes
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)