### PR TITLE
Add password rules for vatrefundagency.co.za

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1196,6 +1196,9 @@
     "vanguardinvestor.co.uk": {
         "password-rules": "minlength: 8; maxlength: 50; required: lower; required: upper; required: digit; required: digit;"
     },
+    "vatrefundagency.co.za": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!@#$%^&*_+=]; allowed: [-!@#$%^&*_+=];"
+    },
     "ventrachicago.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [!@#$%^];"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `vatrefundagency.co.za` (fixes #851).
- Requires a non-dash special (`[!@#$%^&*_+=]`) because the site does not count hyphen toward its symbol requirement; dash remains allowed among other characters.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)