### PR TITLE
Disallow spaces in vanguard.com password rules

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1191,7 +1191,7 @@
         "password-rules": "minlength: 9; required: lower; required: upper; required: digit; required: [@$!%*?&];"
     },
     "vanguard.com": {
-        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: digit; required: special;"
+        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [-!#$%&()*+,./:;<=>?@[^_`{|}~];"
     },
     "vanguardinvestor.co.uk": {
         "password-rules": "minlength: 8; maxlength: 50; required: lower; required: upper; required: digit; required: digit;"


### PR DESCRIPTION
## Summary
- Updates `vanguard.com` password rules so generated passwords cannot include spaces (fixes #954).
- `security-settings.web.vanguard.com` inherits the `vanguard.com` rule; the portal requires 8–20 characters with upper, lower, digit, special, and no spaces.
- Replaces open-ended `required: special` with an explicit punctuation set (no space).

## Test plan
- [x] Diff limited to the `vanguard.com` entry
- [x] JSON parses
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)