### PR TITLE
Add password rules for nfpa.org

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -881,6 +881,9 @@
     "networksolutions.com": {
         "password-rules": "minlength: 12; maxlength: 16;"
     },
+    "nfpa.org": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-@#$%^&*_+={}|:,?/~();.];"
+    },
     "nicovideo.jp": {
         "password-rules": "minlength: 12; maxlength: 32;"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `nfpa.org` (fixes #858).
- Encodes the published 8–16 character policy with upper, lower, digit, and allowed symbols.
- The site asks for 3 of 4 character classes; requiring all four is a compatible stricter generator.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)