### PR TITLE
Add password rules for crc.frc.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -311,6 +311,9 @@
     "crateandbarrel.com": {
         "password-rules": "minlength: 9; maxlength: 64; required: lower; required: upper; required: digit; required: [!\"#$%&()*,.:<>?@^_{|}];"
     },
+    "crc.frc.com": {
+        "password-rules": "allowed: upper, lower, digit, [-_];"
+    },
     "crowdgen.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!#$%&()*+=@^_];"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `crc.frc.com` (fixes #621).
- FANUC CRC only allows alphanumeric characters, underscore, and hyphen.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)