### PR TITLE
Add password rules for neopets.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -872,6 +872,9 @@
     "nelnet.net": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit, [!@#$&*];"
     },
+    "neopets.com": {
+        "password-rules": "minlength: 6; maxlength: 20; required: lower, upper; required: digit; required: digit; allowed: [-~!@#$%^&*()_+={}|;:,.<>?/\\];"
+    },
     "netflix.com": {
         "password-rules": "minlength: 4; maxlength: 60; required: lower, upper, digit; allowed: special;"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `neopets.com` (fixes #516).
- Requires 6-20 characters, at least one letter, at least two digits, and no spaces.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)