### PR TITLE
Add password rules for pinterestcareers.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -923,6 +923,9 @@
     "pilotflyingj.com": {
         "password-rules": "minlength: 7; required: digit; allowed: lower, upper;"
     },
+    "pinterestcareers.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
+    },
     "pixnet.cc": {
         "password-rules": "minlength: 4; maxlength: 16; allowed: lower, upper;"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `pinterestcareers.com` (fixes #515).
- Requires 8-16 characters with lower, upper, digit, and special character.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)