### PR TITLE
Add password rules for boots.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -194,6 +194,9 @@
     "bochk.com": {
         "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [#$%&()*+,.:;<=>?@_];"
     },
+    "boots.com": {
+        "password-rules": "minlength: 8; required: lower, upper; required: lower, upper; required: digit; required: digit;"
+    },
     "box.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: lower; required: upper; required: digit; required: digit;"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `boots.com` (fixes #495).
- Requires at least 8 characters, at least two letters, and at least two digits.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)