### PR TITLE
Add password rules for travel.hawaii.gov

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1151,6 +1151,9 @@
     "training.confluent.io": {
         "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%*@^_~];"
     },
+    "travel.hawaii.gov": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!@#$%^&*_+=]; allowed: [-!@#$%^&*_+=];"
+    },
     "treasurer.mo.gov": {
         "password-rules": "minlength: 8; maxlength: 26; required: lower; required: upper; required: digit; required: [!#$&];"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `travel.hawaii.gov` (fixes #587).
- Require a non-dash special character because the site does not treat hyphen as a symbol.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)