### PR TITLE
CI: run PatternRegexpToPasswordRulesConverter test suite

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,3 +72,13 @@ jobs:
       run: npm install -g ajv-cli
     - name: Validate JSONs against their schemas
       run: ./tools/validate-json-schemas.sh
+
+  pattern-regexp-converter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+    - name: Run PatternRegexpToPasswordRulesConverter tests
+      run: ./tools/PatternRegexpToPasswordRulesConverter/run-tests.sh


### PR DESCRIPTION
## Summary
- Adds a Lint workflow job that runs `tools/PatternRegexpToPasswordRulesConverter/run-tests.sh` (fixes #1166).
- Uses the same pinned `actions/checkout` / `actions/setup-node` versions as the other Lint jobs.

## Test plan
- [x] `./tools/PatternRegexpToPasswordRulesConverter/run-tests.sh` passes locally (53 tests)
- [ ] GitHub Actions Lint job green

Made with [Cursor](https://cursor.com)