### PR TITLE
Add password rules for westfield.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1259,6 +1259,9 @@
     "wellsfargo.com": {
         "password-rules": "minlength: 8; maxlength: 32; required: lower; required: upper; required: digit;"
     },
+    "westfield.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: special;"
+    },
     "wmata.com": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; required: digit; required: [-!@#$%^&*~/\"()_=+\\|,.?[]];"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `westfield.com` (fixes #921).
- Encodes the reported requirements: 8–20 characters with upper, lower, digit, and special.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)