### PR TITLE
Associate Shareworks iOS app with shareworks.com / solium.com

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -152,5 +152,9 @@
     ],
     "V8KLPSD2PL.com.lutron.lsb": [
         "lutron.com"
+    ],
+    "com.solium.SwPtpMobile": [
+        "shareworks.com",
+        "solium.com"
     ]
 }


### PR DESCRIPTION
## Summary
- Associates AppID `com.solium.SwPtpMobile` with ["shareworks.com","solium.com"] (fixes #852).
- Shareworks (bundleId com.solium.SwPtpMobile, App Store id 1098307422) signs in via shareworks.solium.com.

## Test plan
- [x] Diff limited to the new AppID entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)