### PR TITLE
Associate Everty Driver app with everty.network

### DIFF
--- a/quirks/apple-appIDs-to-domains-shared-credentials.json
+++ b/quirks/apple-appIDs-to-domains-shared-credentials.json
@@ -106,6 +106,9 @@
     "3N57B8Z367.com.standard-life.MyPortfolio": [
         "standardlife.co.uk"
     ],
+    "com.everty.evertydriverApp": [
+        "everty.network"
+    ],
     "com.mojang.minecraftlauncher": [
         "microsoft.com",
         "live.com",


### PR DESCRIPTION
## Summary
- Associates AppID `com.everty.evertydriverApp` with ["everty.network"] (fixes #843).
- Everty Driver (bundleId com.everty.evertydriverApp) should suggest credentials saved for app.everty.network.

## Test plan
- [x] Diff limited to the new AppID entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)