### PR TITLE
Add password rules for citiretailservices.citibankonline.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -254,6 +254,9 @@
     "citi.com": {
         "password-rules": "minlength: 8; maxlength: 64; max-consecutive: 2; required: digit; required: upper; required: lower; required: [-~`!@#$%^&*()_\\/|];"
     },
+    "citiretailservices.citibankonline.com": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: digit; allowed: [-!@#$%&*_+=?];"
+    },
     "claimlookup.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@#$%^&+=!];"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `citiretailservices.citibankonline.com` (fixes #611).
- Requires two digits and uses a conservative allowed special set, matching the report that generated strong passwords failed due to digit count / prohibited specials.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)