### PR TITLE
Add password rules for manuscriptcentral.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -791,6 +791,9 @@
     "makemytrip.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [@$!%*#?&];"
     },
+    "manuscriptcentral.com": {
+        "password-rules": "minlength: 8; required: lower, upper; required: digit; required: digit; required: [-];"
+    },
     "marriott.com": {
         "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; allowed: [$!#&@?%=];"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `manuscriptcentral.com` based on the rule form discussed in #685 (letters, two digits, hyphen).
- Lets password managers generate compatible ScholarOne / Manuscript Central credentials without depending on the public validation tool bug.

## Test plan
- [x] Diff limited to the new domain entry
- [x] JSON parses; keys remain sorted
- [ ] Maintainer review / confirmation of live site requirements

Made with [Cursor](https://cursor.com)