### PR TITLE
Add password rules for ais.usvisa-info.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -44,6 +44,9 @@
     "airfrance.us": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit; allowed: [-!#$&+/?@_];"
     },
+    "ais.usvisa-info.com": {
+        "password-rules": "minlength: 8; maxlength: 32; allowed: lower, upper, digit;"
+    },
     "ajisushionline.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [ !#$%&*?@];"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `ais.usvisa-info.com` (fixes #599).
- Restricts generation to alphanumeric passwords (≥8 chars); special-character strong passwords are rejected by the visa appointment service.

## Test plan
- [x] `password-rules-parse.js` passes
- [x] Diff limited to the new domain entry
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)