### PR TITLE
Add password rules for security-settings.web.vanguard.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1052,6 +1052,9 @@
     "secure.snnow.ca": {
         "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper;"
     },
+    "security-settings.web.vanguard.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [-!#$%&()*+,./:;<=>?@[^_`{|}~]; allowed: [-!#$%&()*+,./:;<=>?@[^_`{|}~];"
+    },
     "sephora.com": {
         "password-rules": "minlength: 6; maxlength: 12;"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `security-settings.web.vanguard.com` matching the site policy: 8–20 characters, upper, lower, digit, special character, no spaces.
- Spaces are excluded by listing only the allowed special set in `allowed:` (required letter/digit classes remain implicitly allowed).

Fixes #954

## Test plan
- [x] `node .github/workflows/lint-scripts/password-rules-parse.js` clean
- [ ] CI quirks lint green

Made with [Cursor](https://cursor.com)