### PR TITLE
Add password rules for truity.org

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1157,6 +1157,9 @@
     "truist.com": {
         "password-rules": "minlength: 8; maxlength: 28; max-consecutive: 2; required: lower; required: upper; required: digit; required: [!#$%()*,:;=@_];"
     },
+    "truity.org": {
+        "password-rules": "minlength: 8; maxlength: 10; max-consecutive: 4; required: digit; allowed: lower, upper, [-!\"#$%&()+,/;<=>?[\\^_`{}'*]];"
+    },
     "turkishairlines.com": {
         "password-rules": "minlength: 6; maxlength: 6; required: digit; max-consecutive: 3;"
     },


### PR DESCRIPTION
## Summary
- Adds password rules for `truity.org` from the credit union policy in #431 (length 8–10, digit required, max-consecutive 4, restricted specials).

Fixes #431

## Test plan
- [x] `password-rules-parse.js` clean
- [ ] CI quirks lint green

Made with [Cursor](https://cursor.com)