### PR TITLE
Add shared credentials for Chicago Public Library domains

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -244,6 +244,13 @@
         ]
     },
     {
+        "shared": [
+            "chipublib.bibliocommons.com",
+            "chipublib.org",
+            "chipublib.overdrive.com"
+        ]
+    },
+    {
         "from": [
             "cleanshot.cloud"
         ],


### PR DESCRIPTION
## Summary
- Adds a shared-credentials entry for `chipublib.org`, `chipublib.bibliocommons.com`, and `chipublib.overdrive.com`.

Fixes #357

## Test plan
- [x] Diff is a single shared entry (no unrelated rewrites)
- [ ] CI shared-credentials sort/lint green

Made with [Cursor](https://cursor.com)