### PR TITLE
Add shared credentials for University of Wollongong domains

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -672,6 +672,14 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "shared": [
+            "moodle.uowplatform.edu.au",
+            "solss.uow.edu.au",
+            "uow.edu.au",
+            "uowplatform.edu.au"
+        ]
+    },
+    {
         "from": [
             "nebula.app",
             "watchnebula.com"


### PR DESCRIPTION
## Summary
- Adds shared credentials for `uow.edu.au`, `solss.uow.edu.au`, `uowplatform.edu.au`, and `moodle.uowplatform.edu.au`.

Fixes #535

## Test plan
- [x] Single shared entry only
- [ ] CI shared-credentials lint green

Made with [Cursor](https://cursor.com)