### PR TITLE
Add Radian browser distribution information

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -1332,7 +1332,8 @@
                 "Mac": {
                     "bundle_identifier": "studio.lustral.browser",
                     "code_signing_identifier": "studio.lustral.browser",
-                    "code_signing_team_identifier": "HC9H2R7Z77"
+                    "code_signing_team_identifier": "HC9H2R7Z77",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Radian/User Data/Default/Extensions"
                 }
             },
             "supported_store_identifiers": [

--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -1321,6 +1321,23 @@
             "supported_store_identifiers": [
                 1
             ]
+        },
+        {
+            "long_name": "Radian",
+            "short_name": "Radian",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "studio.lustral.browser",
+                    "code_signing_identifier": "studio.lustral.browser",
+                    "code_signing_team_identifier": "HC9H2R7Z77"
+                }
+            },
+            "supported_store_identifiers": [
+                1
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds distribution information for Radian, a macOS browser with support for Chrome Web Store extensions.

Radian is signed with Team ID `HC9H2R7Z77` and uses the bundle/signing identifier `studio.lustral.browser`.

Happy to provide any additional information if needed!

---

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

