### PR TITLE
Update the todoist.com change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -556,7 +556,7 @@
     "tinyurl.com": "https://tinyurl.com/app/settings/security",
     "tmon.co.kr": "https://login.tmon.co.kr/user/info",
     "tmz.com": "https://shop.tmz.com/user?show=account-tab",
-    "todoist.com": "https://todoist.com/prefs/account",
+    "todoist.com": "https://app.todoist.com/app/settings/account",
     "trakt.tv": "https://trakt.tv/settings#password",
     "trip.com": "https://www.trip.com/membersinfo/profile/",
     "tripadvisor.com": "https://www.tripadvisor.com/Settings-cp",


### PR DESCRIPTION
The existing URL, `https://todoist.com/prefs/account`, now returns HTTP 404 ("Page not found | Todoist") both when logged in and when logged out. Todoist moved its web app to the `app.todoist.com` subdomain, and account settings now live at `https://app.todoist.com/app/settings/account`, which contains the "Password" section with the change password control.

### Verification

| Check | Result |
| --- | --- |
| Old URL | `curl -sSL https://todoist.com/prefs/account` → **404**, final URL `https://www.todoist.com/prefs/account`, title "Page not found \| Todoist" |
| New URL, logged out | **200** — redirects to the Todoist sign-in flow and returns to account settings after authenticating |
| New URL, logged in | Lands directly on Settings → Account, which holds the password controls |

### Why the quirk is still needed

Todoist does not serve the [Well Known URL for Changing Passwords](https://github.com/w3c/webappsec-change-password-url):

```
$ curl -sSI https://todoist.com/.well-known/change-password
301 -> https://www.todoist.com/.well-known/change-password

$ curl -sSI https://www.todoist.com/.well-known/change-password
404
```

So this is a URL correction rather than a removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)