### PR TITLE
Widen the allowed special characters for pay.citizensbank.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -912,7 +912,7 @@
         "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"
     },
     "pay.citizensbank.com": {
-        "password-rules": "minlength: 8; maxlength: 24; required: lower; required: upper; required: digit; allowed: [@!#];"
+        "password-rules": "minlength: 8; maxlength: 24; required: lower; required: upper; required: digit; allowed: [!#$%&*@];"
     },
     "paypal.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower, upper; required: digit, [!@#$%^&*()];"


### PR DESCRIPTION
The existing rule, added in #1146, allows only `[@!#]`. The site actually accepts seven special characters: `! @ # $ % & *`. The rule is therefore more restrictive than necessary, which needlessly reduces the character pool available to password generators.

### The site's stated requirements

```
Password must contain:
8-24 characters
One upper case
One lower case
One number
Optional but recommended:
One of the following special characters: ! @ # $ % & *
User ID cannot be used as the password.
```

### The validation actually enforced

This wording matches what the site enforces client-side. The regular expression is present in the site's main JavaScript bundle (`https://pay.citizensbank.com/main.51036d8cbd3b67b6df74.js`):

```js
new RegExp("^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])[0-9a-zA-Z!@#$%&*]{8,24}$")
```

Reading that regex:

| Fragment | Meaning |
| --- | --- |
| `{8,24}` | `minlength: 8`, `maxlength: 24` |
| `(?=.*\d)` `(?=.*[a-z])` `(?=.*[A-Z])` | `required: digit`, `required: lower`, `required: upper` |
| `[0-9a-zA-Z!@#$%&*]` | complete set of permitted characters — specials are exactly `! @ # $ % & *` |
| *(no special-char lookahead)* | confirms "optional but recommended"; `allowed:` is correct here, not `required:` |

### Testing

Generated 50,000 passwords conforming to the new rule and tested each against the site's regex:

- **0 rejected**
- Each of the four newly permitted characters (`$ % & *`) is accepted
- Characters outside the set (`^ ( ) - _ + = ? / ~`) are rejected
- Lengths of 7 and 25 are rejected; 8 and 24 are accepted

The rule also parses cleanly under `tools/PasswordRulesParser.js`:

```
required: lower | required: upper | required: digit | allowed: [!#$%&*@] | minlength: 8 | maxlength: 24
```

### Note

The "User ID cannot be used as the password" constraint is not expressible in the Password Rules language, and is not a concern for generated passwords.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule
- [x] Information has been included about the website's requirements
- [x] The PR isn't documenting something that would be a common practice among password managers

🤖 Generated with [Claude Code](https://claude.com/claude-code)