### PR TITLE
Reject character classes the converter cannot represent

### DIFF
--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverter.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverter.js
@@ -110,6 +110,12 @@ class PatternRegexpToPasswordRulesConverter {
             return null;
         }
 
+        if (this.#containsUnrepresentableClass(charClassMatch[1])) {
+            console.warn("PatternRegexpToPasswordRulesConverter: Main character class cannot be represented exactly");
+            console.warn("Pattern:", regexp);
+            return null;
+        }
+
         // Parse the validated components
         const required = this.#parseLookaheads(lookaheads);
         const allowed = this.#parseCharacterClassFromMatch(charClassMatch, required);
@@ -193,6 +199,14 @@ class PatternRegexpToPasswordRulesConverter {
             if (this.#containsUnsupportedAlphanumericRange(lookahead)) {
                 return false;
             }
+
+            if (this.#containsUnrepresentableClass(lookahead)) {
+                return false;
+            }
+
+            if (this.#lookaheadHasNoRepresentableRequirement(lookahead)) {
+                return false;
+            }
         }
         return true;
     }
@@ -222,6 +236,64 @@ class PatternRegexpToPasswordRulesConverter {
         }
 
         return false;
+    }
+
+    /**
+     * Check for character classes the converter cannot represent exactly
+     *
+     * These differ from an unsupported range in that the output is still well formed,
+     * so nothing downstream flags it; the rule simply does not mean what the pattern
+     * meant. They are rejected rather than converted.
+     * @private
+     */
+    static #containsUnrepresentableClass(charClass) {
+        // A leading '^' negates the class. Password Rules cannot express negation, and
+        // the '^' is otherwise read as a literal member, which inverts the meaning:
+        // '[^a-z]' converts to 'allowed: lower, [^]'. A '^' elsewhere in the class is a
+        // legitimate literal and stays supported.
+        if (charClass.startsWith("^")) {
+            return true;
+        }
+
+        // An escape whose payload is alphanumeric is removed by the alphanumeric cleanup
+        // in the parsers before escapes are unescaped, leaving a bare backslash that is
+        // emitted as a literal: '[a-zA-Z0-9\s]' converts to 'allowed: ..., [\]'.
+        // \d and \w are the only escapes the converter expands, so they stay supported.
+        for (let index = 0; index < charClass.length - 1; ++index) {
+            if (charClass[index] !== "\\") {
+                continue;
+            }
+
+            const payload = charClass[index + 1];
+            if (/[a-zA-Z0-9]/.test(payload) && payload !== "d" && payload !== "w") {
+                return true;
+            }
+
+            ++index;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check for a lookahead whose requirement cannot be expressed
+     *
+     * A lookahead only maps to a 'required:' tag if it resolves to a standard range or
+     * leaves a non-alphanumeric residue. An enumerated alphanumeric class such as
+     * '[0123456789]' or '[abc]' resolves to neither, and the requirement is currently
+     * dropped while the rest of the rule is still emitted.
+     * @private
+     */
+    static #lookaheadHasNoRepresentableRequirement(lookahead) {
+        const expanded = lookahead.replace(/\\d/g, "0-9").replace(/\\w/g, "a-zA-Z0-9_");
+
+        if (["0-9", "A-Z", "a-z"].some((range) => expanded.includes(range))) {
+            return false;
+        }
+
+        // Mirrors the residue calculation in #parseLookaheads.
+        const remaining = expanded.replace(/[a-zA-Z0-9]/g, "").replace(/\\(.)/g, "$1");
+        return remaining.length === 0;
     }
 
     /**

--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
@@ -497,6 +497,36 @@ class PatternRegexpToPasswordRulesConverterTest {
                 name: "Partial range in main character class",
                 regexp: "^[a-z2-9]{8,}$",
                 shouldBeNull: true
+            },
+            {
+                name: "Negated class in lookahead",
+                regexp: "^(?=.*[0-9])(?=.*[^a-zA-Z0-9])[a-zA-Z0-9!@#$]{8,64}$",
+                shouldBeNull: true
+            },
+            {
+                name: "Negated class in main character class",
+                regexp: "^[^a-z]{8,}$",
+                shouldBeNull: true
+            },
+            {
+                name: "Literal caret is not negation",
+                regexp: "^[a-zA-Z0-9!@#$%^&*]{8,}$",
+                shouldBeNull: false
+            },
+            {
+                name: "Whitespace escape in main character class",
+                regexp: "^[a-zA-Z0-9\\s]{8,20}$",
+                shouldBeNull: true
+            },
+            {
+                name: "Digit shorthand in main character class",
+                regexp: "^[a-z\\d]{8,}$",
+                shouldBeNull: false
+            },
+            {
+                name: "Enumerated alphanumeric class in lookahead",
+                regexp: "^(?=.*[0123456789])[a-zA-Z0-9]{8,20}$",
+                shouldBeNull: true
             }
         ];
 

--- a/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
+++ b/tools/PatternRegexpToPasswordRulesConverter/PatternRegexpToPasswordRulesConverterTest.js
@@ -295,6 +295,11 @@ class PatternRegexpToPasswordRulesConverterTest {
                 name: "Both hyphen and bracket (escaped) in lookahead",
                 regexp: "^(?=.*[\\]-!@])(?=.*[0-9])[a-zA-Z0-9\\]-!@]{8,20}$",
                 expected: "required: [-!@]]; required: digit; allowed: lower, upper; minlength: 8; maxlength: 20;"
+            },
+            {
+                name: "Caret is a literal when it does not lead the character class",
+                regexp: "^[a-zA-Z0-9!@#$%^&*]{8,}$",
+                expected: "allowed: lower, upper, digit, [!@#$%^&*]; minlength: 8;"
             }
         ];
 
@@ -434,6 +439,11 @@ class PatternRegexpToPasswordRulesConverterTest {
                 name: "Escaped backslash in main character class",
                 regexp: "^(?=.*[0-9])[a-z0-9\\\\]{8,20}$",
                 expected: "required: digit; allowed: lower, [\\]; minlength: 8; maxlength: 20;"
+            },
+            {
+                name: "\\d in main character class without a lookahead",
+                regexp: "^[a-z\\d]{8,}$",
+                expected: "allowed: lower, digit; minlength: 8;"
             }
         ];
 
@@ -509,19 +519,9 @@ class PatternRegexpToPasswordRulesConverterTest {
                 shouldBeNull: true
             },
             {
-                name: "Literal caret is not negation",
-                regexp: "^[a-zA-Z0-9!@#$%^&*]{8,}$",
-                shouldBeNull: false
-            },
-            {
                 name: "Whitespace escape in main character class",
                 regexp: "^[a-zA-Z0-9\\s]{8,20}$",
                 shouldBeNull: true
-            },
-            {
-                name: "Digit shorthand in main character class",
-                regexp: "^[a-z\\d]{8,}$",
-                shouldBeNull: false
             },
             {
                 name: "Enumerated alphanumeric class in lookahead",


### PR DESCRIPTION
Character classes the converter cannot represent are silently converted instead of rejected, producing rules that do not match the original pattern.

### Overall Checklist

- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically (N/A — no JSON changes)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

Fixes #1212. Independent of #1160 and #1162, though it follows the rejection approach both established.

## Reproduction

Verified against `08f68a0`.

Negated class, both paths:

- Pattern: `^(?=.*[0-9])(?=.*[^a-zA-Z0-9])[a-zA-Z0-9!@#$]{8,64}$`
- Expected: `null`, because negation is not representable.
- Actual: `required: digit; required: digit, upper, lower, [^]; allowed: [!@#$]; minlength: 8; maxlength: 64;`

- Pattern: `^[^a-z]{8,}$`
- Expected: `null`
- Actual: `allowed: lower, [^]; minlength: 8;` — the inverse of the pattern.

Escape with an alphanumeric payload, main character class:

- Pattern: `^[a-zA-Z0-9\s]{8,20}$`
- Expected: `null`, matching the lookahead path, which already rejects `\s`.
- Actual: `allowed: lower, upper, digit, [\]; minlength: 8; maxlength: 20;`

Enumerated alphanumeric class in a lookahead:

- Pattern: `^(?=.*[0123456789])[a-zA-Z0-9]{8,20}$`
- Expected: `required: digit; ...` or `null`.
- Actual: `allowed: lower, upper, digit; minlength: 8; maxlength: 20;`, with `We shouldn't get here, in #parseLookaheads.` logged and the requirement dropped.

## Change

- Add `#containsUnrepresentableClass`, checked for both lookaheads and the main character class, returning `null` with a `console.warn` consistent with the converter's existing rejection paths.
- Treat a **leading** `^` as negation and reject it. A `^` elsewhere in a class stays a supported literal, which matters because shipped rules in `password-rules.json` use it.
- Reject escapes whose payload is alphanumeric, since normalization strips `[a-zA-Z0-9]` before escapes are unescaped and leaves a bare backslash. `\d` and `\w` are expanded by the converter and remain supported, including in bracket form.
- Add `#lookaheadHasNoRepresentableRequirement` for enumerated alphanumeric classes, which resolve to neither a standard range nor a non-alphanumeric residue. This replaces the `We shouldn't get here` path, where the requirement was dropped but the rule still emitted.
- Add regression coverage for all four rejections, plus two must-still-convert guards: literal mid-class `^` and `\d` inside the main character class.

## Verification

Ran `sh tools/PatternRegexpToPasswordRulesConverter/run-tests.sh`: 59 tests pass, from 53 before.

Running the six new cases against the unpatched converter fails 4 of 59 — the four rejection cases — so the new tests exercise the change rather than merely accompanying it. The two must-still-convert cases pass both before and after, which is what makes them useful as guards.

## Note

`[^A-Za-z0-9]` maps closely onto the existing `special` identifier, which `PasswordRulesParser.js` supports and `password-rules.json` uses, so that particular negation could plausibly be converted rather than rejected. I have not done that here: it is a larger decision about scope than the rest of this change, and rejecting is the conservative option. Happy to follow up if you would prefer it converted.
