### PR TITLE
Merge pull reguest 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,24 @@ Project maintainers are expected to always follow the project's [Code of Conduct
 ## Project Governance
 
 Although we expect this to happen very infrequently, Apple reserves the right to make changes, including changes to data format and scope, to the project at any time.
+include a webauthn plus fido enterprise grade passkey plus a sigin auth
+include all necessary certifications to claim passkey 
+SYSTEM PROMPT — SIGN‑IN TRIGGER
+Follow these rules:
+1. Check if a passkey exists for this user on this device.
+   - If a valid passkey is present, return: AUTHENTICATE_WITH_PASSKEY.
+   - If a passkey exists but is not bound to this device, return: REBIND_PASSKEY.
+2. If no passkey exists:
+   - Return: CREATE_NEW_PASSKEY.
+3. If the user is attempting password authentication:
+   - Validate password format and policy.
+   - If valid, return: AUTHENTICATE_WITH_PASSWORD.
+   - If invalid, return: PASSWORD_POLICY_FAILURE.
+4. Always return one of the following machine‑readable actions:
+   - AUTHENTICATE_WITH_PASSKEY
+   - REBIND_PASSKEY
+   - CREATE_NEW_PASSKEY
+   - AUTHENTICATE_WITH_PASSWORD
+   - PASSWORD_POLICY_FAILURE
+5. Never return explanations unless explicitly requested.
+   Only return the action token.


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [ ] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [x] You believe that the domains were associated at some point in the past and can explain that relationship
