### PR TITLE
Add a password rule for venmo.com

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1196,6 +1196,9 @@
     "vanguardinvestor.co.uk": {
         "password-rules": "minlength: 8; maxlength: 50; required: lower; required: upper; required: digit; required: digit;"
     },
+    "venmo.com": {
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower; required: upper; required: digit; required: [~!@#$%^&*()+=];"
+    },
     "ventrachicago.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit, [!@#$%^];"
     },


### PR DESCRIPTION
Venmo's change password form at
https://account.venmo.com/settings/profile/change-password states:

    · Minimum 8 characters, maximum 20
    · Must include upper and lower case letters
    · Must include a number and one of these: (~!@#$%^&*()+=)

Without a rule, generated passwords take the default hyphenated form (e.g. "toznag-6rucde-movPuz"), which contains no character from the required (~!@#$%^&*()+=) set.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)