### PR TITLE
Add change password URL for battle.net, update change password URL for marriott.com, autoformat JSON files 

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -343,7 +343,7 @@
     "marca.com": "https://www.marca.com/micuenta/v1/user-area/account",
     "marketwatch.com": "https://customercenter.marketwatch.com/account#password?mod=ql",
     "marktplaats.nl": "https://www.marktplaats.nl/account/password-reset/confirm.html",
-    "marriott.com": "https://www.marriott.com/loyalty/myAccount/changePassword.mi",
+    "marriott.com": "https://www.marriott.com/loyalty/myAccount/profile.mi?editChangePassword=true",
     "mathworks.com": "https://mathworks.com/mwaccount/profiles/password/change",
     "maxpreps.com": "https://secure.maxpreps.com/utility/member/forgotpassword.aspx",
     "me-qr.com": "https://admin.me-qr.com/profile",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -91,6 +91,7 @@
     "bankofamerica.com": "https://secure.bankofamerica.com/auth/security-center/main/?activity=changePasscode",
     "barnesandnoble.com": "https://www.barnesandnoble.com/account/manage/settings/",
     "bathandbodyworks.com": "https://www.bathandbodyworks.com/my-account/edit-profile",
+    "battle.net": "https://account.battle.net/security",
     "bayareafastrak.org": "https://www.bayareafastrak.org/vector/account/home/ftAccountSettings.do",
     "bbq-grill-world.de": "https://www.bbq-grill-world.de/customer/account/edit/changepass/1/",
     "bedbathandbeyond.com": "https://www.bedbathandbeyond.com/store/account/personalinfo",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -944,11 +944,11 @@
     },
     {
         "from": [
-          "workflowmanager.app",
-          "login.workflowmanager.app"
+            "workflowmanager.app",
+            "login.workflowmanager.app"
         ],
         "to": [
-          "infotechexpress.com"
+            "infotechexpress.com"
         ]
     },
     {

--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -731,7 +731,9 @@
                     "code_signing_team_identifier": "HKE973VLUW"
                 }
             },
-            "supported_store_identifiers": []
+            "supported_store_identifiers": [
+
+            ]
         },
         {
             "long_name": "Tencent QQ Browser",
@@ -922,14 +924,14 @@
             "supported_platforms": [
                 "Mac"
             ],
-             "platform_specific_information": {
-                 "Mac": {
-                     "bundle_identifier": "ai.perplexity.comet",
-                     "code_signing_identifier": "ai.perplexity.comet",
-                     "code_signing_team_identifier": "7S8W4W365S",
-                     "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet/Default/Extensions"
-                 }
-             },
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "ai.perplexity.comet",
+                    "code_signing_identifier": "ai.perplexity.comet",
+                    "code_signing_team_identifier": "7S8W4W365S",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet/Default/Extensions"
+                }
+            },
             "supported_store_identifiers": [
                 1
             ]
@@ -940,14 +942,14 @@
             "supported_platforms": [
                 "Mac"
             ],
-             "platform_specific_information": {
-                 "Mac": {
-                     "bundle_identifier": "ai.perplexity.comet-beta",
-                     "code_signing_identifier": "ai.perplexity.comet-beta",
-                     "code_signing_team_identifier": "7S8W4W365S",
-                     "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet Beta/Default/Extensions"
-                 }
-             },
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "ai.perplexity.comet-beta",
+                    "code_signing_identifier": "ai.perplexity.comet-beta",
+                    "code_signing_team_identifier": "7S8W4W365S",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet Beta/Default/Extensions"
+                }
+            },
             "supported_store_identifiers": [
                 1
             ]
@@ -958,14 +960,14 @@
             "supported_platforms": [
                 "Mac"
             ],
-             "platform_specific_information": {
-                 "Mac": {
-                     "bundle_identifier": "ai.perplexity.comet-canary",
-                     "code_signing_identifier": "ai.perplexity.comet-canary",
-                     "code_signing_team_identifier": "7S8W4W365S",
-                     "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet Canary/Default/Extensions"
-                 }
-             },
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "ai.perplexity.comet-canary",
+                    "code_signing_identifier": "ai.perplexity.comet-canary",
+                    "code_signing_team_identifier": "7S8W4W365S",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet Canary/Default/Extensions"
+                }
+            },
             "supported_store_identifiers": [
                 1
             ]
@@ -976,14 +978,14 @@
             "supported_platforms": [
                 "Mac"
             ],
-             "platform_specific_information": {
-                 "Mac": {
-                     "bundle_identifier": "ai.perplexity.comet-dev",
-                     "code_signing_identifier": "ai.perplexity.comet-dev",
-                     "code_signing_team_identifier": "7S8W4W365S",
-                     "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet Dev/Default/Extensions"
-                 }
-             },
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "ai.perplexity.comet-dev",
+                    "code_signing_identifier": "ai.perplexity.comet-dev",
+                    "code_signing_team_identifier": "7S8W4W365S",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Comet Dev/Default/Extensions"
+                }
+            },
             "supported_store_identifiers": [
                 1
             ]
@@ -1155,40 +1157,40 @@
             ]
         },
         {
-           "long_name": "Phi",
-           "short_name": "Phi",
-           "supported_platforms": [
-               "Mac"
-           ],
-           "platform_specific_information": {
-               "Mac": {
-                   "bundle_identifier": "com.phibrowser.Mac",
-                   "code_signing_identifier": "com.phibrowser.Mac",
-                   "code_signing_team_identifier": "87DQ3HMK5G",
-                   "extensions_install_path_relative_to_user_library_directory": "Application Support/com.phibrowser.Mac/Default/Extensions"
-               }
-           },
-           "supported_store_identifiers": [
-               1
-           ]
-       },
-       {
-           "long_name": "Phi Canary",
-           "short_name": "Phi Canary",
-           "supported_platforms": [
-               "Mac"
-           ],
-           "platform_specific_information": {
-               "Mac": {
-                   "bundle_identifier": "com.phibrowser.canary.Mac",
-                   "code_signing_identifier": "com.phibrowser.canary.Mac",
-                   "code_signing_team_identifier": "87DQ3HMK5G",
-                   "extensions_install_path_relative_to_user_library_directory": "Application Support/com.phibrowser.canary.Mac/Default/Extensions"
-               }
-           },
-           "supported_store_identifiers": [
-               1
-           ]
+            "long_name": "Phi",
+            "short_name": "Phi",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.phibrowser.Mac",
+                    "code_signing_identifier": "com.phibrowser.Mac",
+                    "code_signing_team_identifier": "87DQ3HMK5G",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.phibrowser.Mac/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1
+            ]
+        },
+        {
+            "long_name": "Phi Canary",
+            "short_name": "Phi Canary",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.phibrowser.canary.Mac",
+                    "code_signing_identifier": "com.phibrowser.canary.Mac",
+                    "code_signing_team_identifier": "87DQ3HMK5G",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/com.phibrowser.canary.Mac/Default/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1
+            ]
         },
         {
             "long_name": "Shift Browser",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

I verified the change password URLs and ran `tools/autoformat-json-files.rb` for the auto formatting. 

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state