### PR TITLE
Add shared credentials for sony.com / playstation.com / sonyentertain…

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -503,6 +503,8 @@
     "soap2day.to": "https://soap2day.to/home/user/changepassword",
     "solitaired.com": "https://solitaired.com/user/reset-password?",
     "sonos.com": "https://www.sonos.com/myaccount/user/profile/",
+    "sony.com": "https://id.sonyentertainmentnetwork.com/id/management/#/p/security",
+    "sonyentertainmentnetwork.com": "https://id.sonyentertainmentnetwork.com/id/management/#/p/security",
     "soundcloud.com": "https://soundcloud.com/settings",
     "southwest.com": "https://www.southwest.com/loyalty/myaccount/profile-security.html",
     "spankbang.com": "https://spankbang.com/users/account",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1076,6 +1076,9 @@
     "sjwaterhub.com": {
         "password-rules": "minlength: 8; maxlength: 30; required: digit, lower, upper; allowed: [!#%&*.];"
     },
+    "sony.com": {
+        "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 2; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
+    },
     "southwest.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: upper; required: digit; allowed: lower, [!@#$%^*(),.;:/\\];"
     },

--- a/quirks/shared-credentials-historical.json
+++ b/quirks/shared-credentials-historical.json
@@ -506,12 +506,6 @@
     },
     {
         "shared": [
-            "sonyentertainmentnetwork.com",
-            "sony.com"
-        ]
-    },
-    {
-        "shared": [
             "spark.net",
             "jdate.com"
         ]

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -765,6 +765,13 @@
     },
     {
         "shared": [
+            "playstation.com",
+            "sony.com",
+            "sonyentertainmentnetwork.com"
+        ]
+    },
+    {
+        "shared": [
             "postnl.nl",
             "postnl.be"
         ]


### PR DESCRIPTION
…mentnetwork.com, add password rule and change password URLs

<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `shared`, the new group serves login pages on each of the included domains, and those login pages accept accounts from the others. (For example, we wouldn't use a `shared` association from `google.co.il` to `google.com`, because `google.co.il` redirects to `accounts.google.com` for sign in.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

#### for shared-credentials-historical.json
- [ ] You believe that the domains were associated at some point in the past and can explain that relationship
