### PR TITLE
Add a password rules quirk for activision.com

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -15,6 +15,7 @@
     "accounts.pcid.ca": "https://accounts.pcid.ca/forgot-password",
     "acehardware.com": "https://www.acehardware.com/myaccount#settings",
     "acorns.com": "https://app.acorns.com/settings/change-password",
+    "activision.com": "https://s.activision.com/activision/profile",
     "adafruit.com": "https://accounts.adafruit.com/settings/password",
     "adobe.com": "https://account.adobe.com/security",
     "adultfriendfinder.com": "https://adultfriendfinder.com/p/update.cgi?p=my_account_update_account_password",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -17,6 +17,9 @@
     "act.org": {
         "password-rules": "minlength: 8; maxlength: 64; required: lower; required: upper; required: digit; required: [!#$%&*@^];"
     },
+    "activision.com": {
+        "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: lower, upper; required: digit;"
+    },
     "admiral.com": {
         "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"
     },


### PR DESCRIPTION
Note that Activision accepts passwords of at most 20 characters (despite the website indicating that the max length is 30 characters).

The website also enforces no more than 2 consecutive characters, and also no symbols.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)