### PR TITLE
Add pandora.com change password URL quirk

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -421,6 +421,7 @@
     "overleaf.com": "https://www.overleaf.com/user/settings",
     "overstock.com": "https://www.overstock.com/myaccount/account/email-password",
     "padlet.com": "https://padlet.com/dashboard/settings/password",
+    "pandora.com": "https://www.pandora.com/settings/info",
     "paramountplus.com": "https://www.paramountplus.com/account/",
     "patreon.com": "https://www.patreon.com/settings/account",
     "paypal.com": "https://www.paypal.com/myaccount/security/password/change",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state