### PR TITLE
Add password rules quirks for Xiaomi and Samsung

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -9,7 +9,10 @@
         "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: special;"
     },
     "account.samsung.com": {
-        "password-rules": "minlength: 8; maxlength: 15; required: digit; required: special; required: upper,lower;"
+        "password-rules": "minlength: 8; maxlength: 15; max-consecutive: 3; required: digit; required: special; required: upper,lower;"
+    },
+    "account.xiaomi.com": {
+        "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
     },
     "acmemarkets.com": {
         "password-rules": "minlength: 8; maxlength: 40; required: upper; required: [!#$%&*@^]; allowed: lower,digit;"


### PR DESCRIPTION
For Xiaomi: add password rules (8-16 digits, requiring digits and letters, letters and symbols, digits and symbols, or all three).

For Samsung edit the password rules to reflect that they don't allow more than 3 of the same consecutive characters.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)