### PR TITLE
Add shared credentials for Hugging Face (hf.co → huggingface.co)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -549,6 +549,15 @@
     },
     {
         "from": [
+            "hf.co"
+        ],
+        "to": [
+            "huggingface.co"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "ing.de"
         ],
         "to": [


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (SSL certificates, DNS entries, valid links between sites, legal documents etc.)
- [x] If using `from` and `to`, the new group, the `from` domain(s) redirect to the `to` domain to log in.

## Summary

Adds a `from`/`to` shared-credentials entry so password managers can offer `huggingface.co` credentials on `hf.co` URLs.

- `hf.co` is Hugging Face’s short domain
- It redirects to `huggingface.co` (including `/login`)
- `fromDomainsAreObsoleted: true` matches the redirect pattern used for entries like `discordapp.com` → `discord.com`

## Evidence

```text
$ curl -sI https://hf.co | rg -i '^(HTTP|Location):'
HTTP/1.1 307 Temporary Redirect
Location: https://huggingface.co/

$ curl -sI https://hf.co/login | rg -i '^(HTTP|Location):'
HTTP/1.1 307 Temporary Redirect
Location: https://huggingface.co/login
```

## Test plan

- [x] Entry inserted in alphabetical order by first domain (`heroku.com` → `hf.co` → `ing.de`)
- [x] `quirks/shared-credentials.json` validates against the schema
- [ ] Maintainer review of shared-backend / redirect relationship

No `change-password-URLs` entry: `https://huggingface.co/.well-known/change-password` currently returns 401, so that is deferred.
