### PR TITLE
Add mega.nz change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -350,6 +350,7 @@
     "me-qr.com": "https://admin.me-qr.com/profile",
     "mediafire.com": "https://www.mediafire.com/myaccount/accountbilling.php#change-pwd-block",
     "mediamarkt.de": "https://www.mediamarkt.de/de/myaccount/profile",
+    "mega.nz": "https://mega.nz/fm/account/security",
     "meliuz.com.br": "https://www.meliuz.com.br/minha-conta/meus-dados/senha",
     "menards.com": "https://www.menards.com/main/accountoverview.html",
     "mercadolivre.com.br": "https://www.mercadolivre.com.br/security/password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for change-password-URLs.json
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] The URL either makes the experience better or no worse than being directed to just the domain in a non-logged-in state
