### PR TITLE
Adjust the `max-consecutive` part of the password rules quirk on zoom.us

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -1302,6 +1302,6 @@
         "password-rules": "minlength: 8; required: upper; required: digit; allowed: lower, special;"
     },
     "zoom.us": {
-        "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 6; required: lower; required: upper; required: digit;"
+        "password-rules": "minlength: 8; maxlength: 32; max-consecutive: 3; required: lower; required: upper; required: digit;"
     }
 }


### PR DESCRIPTION
Zoom, at the time of writing, rejects password rules with more than 3 consecutive characters, not 6.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)