### PR TITLE
Add Linen Browser distribution information

### DIFF
--- a/quirks/web-browser-extension-distribution-information.json
+++ b/quirks/web-browser-extension-distribution-information.json
@@ -1323,6 +1323,25 @@
             "supported_store_identifiers": [
                 1
             ]
+        },
+        {
+            "long_name": "Linen Browser",
+            "short_name": "Linen",
+            "supported_platforms": [
+                "Mac"
+            ],
+            "platform_specific_information": {
+                "Mac": {
+                    "bundle_identifier": "com.kavoye.Linen",
+                    "code_signing_identifier": "com.kavoye.Linen",
+                    "code_signing_team_identifier": "T8677WC8DG",
+                    "extensions_install_path_relative_to_user_library_directory": "Application Support/Linen/Extensions"
+                }
+            },
+            "supported_store_identifiers": [
+                1,
+                3
+            ]
         }
     ]
 }


### PR DESCRIPTION
**Linen Browser**: [github.com/kavoye/linen-browser](https://github.com/kavoye/linen-browser)

An open-source, WebKit-based web browser for macOS, signed with Developer ID and notarized. Linen installs extensions from the Chrome Web Store and Firefox Add-ons, and supports the Native Messaging Host protocol used by the iCloud Passwords extension.

- **Download (notarized build):** https://github.com/kavoye/linen-browser/releases/latest
- **Bundle & code signing identifier:** `com.kavoye.Linen`
- **Team ID:** `T8677WC8DG` (Developer ID Application: Viacheslav Shkliarov)

Verify with:

    codesign -dvv /Applications/Linen.app

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update
