### PR TITLE
Add shared credentials for HDFC Bank (hdfcbank.com → hdfc.bank.in)

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -488,6 +488,9 @@
     "hdfc.bank.in": {
         "password-rules": "minlength: 8; maxlength: 15; required: digit; required: upper, lower; allowed: [@&:|.^~#_$!)?];"
     },
+    "hdfcbank.com": {
+        "password-rules": "minlength: 8; maxlength: 15; required: digit; required: upper, lower; allowed: [@&:|.^~#_$!)?];"
+    },
     "hertz-japan.com": {
         "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower; required: upper; required: digit; required: [#$%^&!@];"
     },

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -534,6 +534,15 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "from": [
+            "hdfcbank.com"
+        ],
+        "to": [
+            "hdfc.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "hejj.io",
             "skoophr.com"


### PR DESCRIPTION
### Summary
HDFC Bank rebranded its public site to `hdfc.bank.in` and now serves NetBanking at `now.hdfc.bank.in`, while many bookmarks, reset/register links, and saved passwords still use `hdfcbank.com`. This PR:

1. Adds a `from`/`to` shared-credentials group so passwords saved for `hdfcbank.com` autofill on `hdfc.bank.in`.
2. Copies the existing `hdfc.bank.in` IPIN rule onto `hdfcbank.com` (same 8–15 policy).

This is one bank only (HDFC). No change-password URL: the remaining reset pages are OTP flows, not a logged-in password change page, and `netbanking.hdfcbank.com` is Cloudflare-challenged from some networks.

### Shared credentials evidence (live, 2026-09-02)

**Login on `hdfcbank.com` redirects to `hdfc.bank.in`:**
- `https://now.hdfcbank.com/` → 301 `https://now.hdfc.bank.in/` → 302 `https://now.hdfc.bank.in/retail-app/` (200, title *Welcome to HDFC Bank NetBanking*).
- `https://netbanking.hdfcbank.com/netbanking/` → 308 `https://now.hdfc.bank.in/` → same retail-app login.

That matches CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in). `fromDomainsAreObsoleted` is `true` because those login hostnames no longer serve the form themselves.

**Official site still treats both names as HDFC NetBanking:**
- `https://www.hdfc.bank.in/` LOGIN menu lists NetBanking. CSP `default-src` / `frame-ancestors` explicitly allow `*.hdfcbank.com` and `*.hdfc.bank.in`.
- Interstitial `https://v.hdfc.bank.in/assets/popuppages/netbanking.html` (live 200):
  - Proceed Now: `https://now.hdfc.bank.in/retail-app/`
  - Regenerate IPIN: `https://netbanking.hdfcbank.com/netbanking/IpinResetUsingOTP.htm`
  - Register: `https://netbanking.hdfcbank.com/netbanking/registrationUsingOTP.htm`
- Homepage still also links to `https://netbanking.hdfc.bank.in/netbanking/` (that hostname currently has no public DNS) and the same interstitial.

`shared` would be wrong: `hdfcbank.com` NetBanking URLs do not keep a login form; they bounce to `now.hdfc.bank.in`.

### Password rules evidence

Existing quirk for `hdfc.bank.in` (merged in #1138):
`minlength: 8; maxlength: 15; required: digit; required: upper, lower; allowed: [@&:|.^~#_$!)?];`

This PR applies the **same** string to `hdfcbank.com` so generation stays consistent across the shared backend.

Live T&amp;C (`https://www.hdfc.bank.in/resources/way-to-bank/online-banking/net-banking/terms-and-conditions`, section 1.15 IPIN):

> Choose an IPIN which shall be at least of 6 characters long or such minimum number as may be specified by the Bank from time to time and shall consist of a mix of alphabets, numbers and special characters…

The T&amp;C floor (6) is weaker than the registration UI. Credit-card registration `CCUserReg.html` (Wayback 2025-04-15 of `https://netbanking.hdfcbank.com/netbanking/CCUserReg.html`) stated **min 8 / max 15**, mix of alphabets, numbers, special characters, case-sensitive; client JS used `minlen=8, maxlen=15` and rejected `%`, `;`, `"`, `'`. That matches the existing `hdfc.bank.in` quirk (8–15, digit + letter, limited specials). The live `now.hdfc.bank.in/retail-app/` SPA is a Customer ID login (password collected after ID); it does not contradict the 8–15 IPIN cap.

The rule was parsed with this repo’s `PasswordRulesParser.js` (min 8, max 15, required digit, required upper-or-lower, allowed specials). I did **not** submit generated IPINs into a live reset/register form: those `hdfcbank.com` pages return Cloudflare 403 from this environment and require OTP + debit-card details.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/) (same rule already merged for `hdfc.bank.in` in #1138; parser in this repo accepts it)
- [x] Information has been included about the website's requirements (live T&amp;C quote, Wayback registration UI, redirects)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live redirects, official interstitial links, CSP, same NetBanking product)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.