### PR TITLE
Add shared credentials for ICICI Bank (icicibank.com → icici.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -558,6 +558,15 @@
     },
     {
         "from": [
+            "icicibank.com"
+        ],
+        "to": [
+            "icici.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "ing.de"
         ],
         "to": [


### PR DESCRIPTION
### Summary
ICICI Bank moved its public site and retail Net Banking login from `icicibank.com` to `icici.bank.in`. This PR adds a `from`/`to` shared-credentials group so passwords saved for `icicibank.com` autofill on `icici.bank.in`.

No `password-rules` entry: the live login SPA and the Net Banking marketing page do not publish length/charset requirements (password generation is OTP + debit-card Grid Card Authentication). I did not invent a rule.

HDFC was merged separately in #1239; this PR is ICICI only.

### Live evidence (2026-09-02)

**Marketing site**
- `https://www.icicibank.com/` → **301** `https://www.icici.bank.in/` (200).
- `https://icici.bank.in/` → 301 `https://www.icici.bank.in/`.

**Primary Net Banking login**
- Official Net Banking page (`https://www.icici.bank.in/personal-banking/ways-to-bank/net-banking`) and homepage CTAs use `https://retailnetbanking.icici.bank.in/login-page` (200, title *ICICI Bank - Login to Net Banking*).
- Canonical Infinity URL still advertised in older flows:
  `https://infinity.icicibank.com/corp/AuthenticationController?FORMSGROUP_ID__=AuthenticationFG&__START_TRAN_FLAG__=Y&FG_BUTTONS__=LOAD&ACTION.LOAD=Y&AuthenticationFG.LOGIN_FLAG=1&BANK_ID=ICI`
  → **301** `https://retailnetbanking.icici.bank.in/login-page?...` (same SPA).

That is CONTRIBUTING’s `from`/`to` case. `fromDomainsAreObsoleted` is `true` because those login URLs no longer serve the form on `icicibank.com`.

Note: some older Infinity query variants (`__CALL_MODE__=10` / `91`, “get User ID” / generate-password helpers) still return 200 on `infinity.icicibank.com`. The advertised login itself redirects.

`www.icici.bank.in` CSP `frame-src` still lists `infinity.icicibank.com`, and `frame-ancestors` lists `retailnetbanking.icici.bank.in` — same bank, new retail host.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 301s, official Net Banking CTAs, CSP)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.