### PR TITLE
Add shared credentials for Axis Bank (axisbank.com → axis.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -179,6 +179,15 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "from": [
+            "axisbank.com"
+        ],
+        "to": [
+            "axis.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "bgg.cc",
             "boardgamegeek.com",


### PR DESCRIPTION
### Summary
Axis moved its public site from `axisbank.com` to `axis.bank.in`. This adds a `from`/`to` shared-credentials group so passwords saved for `axisbank.com` autofill on `axis.bank.in`.

`fromDomainsAreObsoleted` is `true` because the old host no longer serves logins or marketing; it 301s to the new one. I use Axis Internet Banking first-hand.

This PR is Axis only. HDFC is already in the file (`hdfcbank.com` → `hdfc.bank.in`). ICICI is a separate open PR (#1240).

### Live evidence (2026-09-04 UTC)
- `https://www.axisbank.com/` → HTTP 301 `Location: https://www.axis.bank.in`
- `https://axisbank.com/` → HTTP 301 `Location: https://www.axis.bank.in/sitemap`
- `https://www.axis.bank.in/` → HTTP 200

That is CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in).

### First-hand + archive (login migration, not bare marketing redirect)

I use Axis Internet Banking first-hand.

`www.axisbank.com` was the marketing entry (title: Personal Banking | Internet Banking). The Login CTA sent you to the retail form on `retail.axisbank.co.in` (`AxisRetailLogin`), not a passwordless redirect.

Archive (Jan 2020 homepage with Login → `retail.axisbank.co.in/.../AxisRetailLogin`):
https://web.archive.org/web/20200101120000/https://www.axisbank.com/

Live today: `www.axisbank.com` → 301 `www.axis.bank.in`. Same password-migration case as CONTRIBUTING `from`/`to`.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 301s to `axis.bank.in`)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.