### PR TITLE
Add shared credentials for Federal Bank (federalbank.co.in → federal.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -466,6 +466,15 @@
     },
     {
         "from": [
+            "federalbank.co.in"
+        ],
+        "to": [
+            "federal.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "flaglerclerk.com"
         ],
         "to": [


### PR DESCRIPTION
### Summary
Federal Bank moved its public site from `federalbank.co.in` to `federal.bank.in`. This adds a `from`/`to` shared-credentials group so passwords saved for `federalbank.co.in` autofill on `federal.bank.in`.

`fromDomainsAreObsoleted` is `true` because the old host no longer serves logins or marketing; it 301s to the new one. I use Federal Bank Internet Banking first-hand.

This PR is Federal Bank only. No Axis, HDFC, ICICI, or other quirks.

### Live evidence (2026-09-04 UTC, `curl -sI`)
Re-checked immediately before this description. Observed `Location` headers:

- `https://www.federalbank.co.in/` → HTTP 301 `Location: https://www.federal.bank.in/` (05:20:11 UTC; same 301/`Location` on the first probe at 05:18:54 UTC)
- `https://federalbank.co.in/` → HTTP 301 `Location: https://www.federal.bank.in/` (05:19:51 UTC)
- `https://www.federal.bank.in/` → HTTP 200 (05:18:56 UTC)

That is CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in).

`tools/validate-json-schemas.sh` passed (`quirks/shared-credentials.json valid`).

### First-hand + archive (login migration, not bare marketing redirect)

I use Federal Bank FedNet first-hand.

The User ID / password form lived on the FedNet host (`www.fednetbank.com` / later `fednet.federalbank.co.in`), reached from `federalbank.co.in` — not a marketing-only hop.

Archive (FedNet login page mentioning Internet Banking UserID and Password, Jan 2012):
https://web.archive.org/web/20120129124317/https://www.fednetbank.com/

Live today: `www.federalbank.co.in` → `federal.bank.in`; `fednet.federalbank.co.in` → 301 `fednet.federal.bank.in`.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 301s to `federal.bank.in`)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.