### PR TITLE
Add shared credentials for Bank of Baroda (bankofbaroda.in → bankofbaroda.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -179,6 +179,15 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "from": [
+            "bankofbaroda.in"
+        ],
+        "to": [
+            "bankofbaroda.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "bgg.cc",
             "boardgamegeek.com",


### PR DESCRIPTION
### Summary
Bank of Baroda moved its public site from `bankofbaroda.in` to `bankofbaroda.bank.in`. This adds a `from`/`to` shared-credentials group so passwords saved for `bankofbaroda.in` autofill on `bankofbaroda.bank.in`.

`fromDomainsAreObsoleted` is `true` because the old host no longer serves logins or marketing; it 301s to the new one. I use Bank of Baroda Internet Banking first-hand.

This PR is Bank of Baroda only. No Axis, Federal, HDFC, ICICI, or other quirks. HDFC is already in the file (`hdfcbank.com` → `hdfc.bank.in`). Axis is #1242. Federal is #1243.

### Live evidence (2026-09-04 UTC, `curl -sI`)
Re-checked immediately before this description (05:27:54 UTC). Observed `Location` headers:

- `https://www.bankofbaroda.in/` → HTTP 301 `Location: https://bankofbaroda.bank.in/`
- `https://bankofbaroda.in/` → HTTP 301 `Location: https://bankofbaroda.bank.in/`
- `https://bankofbaroda.bank.in/` HEAD (`curl -sI`) → HTTP 404 (HEAD is not implemented on the new host)
- `https://bankofbaroda.bank.in/` GET (`curl -sI -X GET`) → HTTP 200

That is CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in).

`tools/validate-json-schemas.sh` passed (`quirks/shared-credentials.json valid`).

### First-hand + archive (login migration, not bare marketing redirect)

I use Bank of Baroda e-Banking / bob World first-hand.

`bankofbaroda.in` was the public entry. The actual User ID / password form was on `feba.bobibanking.com` Finacle `AuthenticationController` (`USER_PRINCIPAL` + password / access code) — same pattern as ICICI’s infinity host.

Archive (Nov 2020 login form — User ID label + `input type=password`):
https://web.archive.org/web/20201118000000/https://feba.bobibanking.com/corp/AuthenticationController?FORMSGROUP_ID__=AuthenticationFG&__START_TRAN_FLAG__=Y&FG_BUTTONS__=LOAD&ACTION.LOAD=Y&AuthenticationFG.LOGIN_FLAG=1&BANK_ID=012

Live today: `www.bankofbaroda.in` → 301 `bankofbaroda.bank.in`.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 301s to `bankofbaroda.bank.in`)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.