### PR TITLE
Add shared credentials for IDFC First Bank (idfcfirstbank.com → idfcfirst.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -558,6 +558,15 @@
     },
     {
         "from": [
+            "idfcfirstbank.com"
+        ],
+        "to": [
+            "idfcfirst.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "ing.de"
         ],
         "to": [


### PR DESCRIPTION
### Summary
IDFC First Bank moved its public site from `idfcfirstbank.com` to `idfcfirst.bank.in`. This adds a `from`/`to` shared-credentials group so passwords saved for `idfcfirstbank.com` autofill on `idfcfirst.bank.in`.

`fromDomainsAreObsoleted` is `true` because the old host no longer serves logins or marketing; it 301s to the new one. I use IDFC First Bank Internet Banking first-hand.

This PR is IDFC First Bank only. No Axis, Federal, Bank of Baroda, HDFC, ICICI, or other quirks. HDFC is already in the file (`hdfcbank.com` → `hdfc.bank.in`). Axis is #1242. Federal is #1243. Bank of Baroda is #1244. ICICI is #1240.

### Live evidence (2026-09-04 UTC, `curl -sI`)
Re-checked immediately before this description (05:32:40 UTC). Observed `Location` headers:

- `https://www.idfcfirstbank.com/` → HTTP 301 `Location: https://www.idfcfirst.bank.in/`
- `https://idfcfirstbank.com/` → HTTP 301 `Location: https://www.idfcfirst.bank.in/`
- `https://www.idfcfirst.bank.in/` HEAD (`curl -sI`) → HTTP 200
- `https://www.idfcfirst.bank.in/` GET (`curl -sI -X GET`) → HTTP 200
- `https://idfcfirst.bank.in/` → HTTP 301 `Location: https://www.idfcfirst.bank.in/`

That is CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in).

`tools/validate-json-schemas.sh` passed (`quirks/shared-credentials.json valid`).

### First-hand + live host migration

I use IDFC FIRST net banking first-hand.

Marketing lived on `idfcfirstbank.com`; the login app lived on `my.idfcfirstbank.com`. Wayback form HTML timed out from my network this pass, so I’m not inventing an archive link — happy to add one when a clean CDX snapshot is available.

Live today (re-checked):
- `www.idfcfirstbank.com` → 301 `www.idfcfirst.bank.in`
- `my.idfcfirstbank.com` → 307 `my.idfcfirst.bank.in`

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 301s to `idfcfirst.bank.in`)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.