### PR TITLE
Add shared credentials for SBI Online (onlinesbi.sbi → onlinesbi.sbi.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -716,6 +716,15 @@
     },
     {
         "from": [
+            "onlinesbi.sbi"
+        ],
+        "to": [
+            "onlinesbi.sbi.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "overstock.com"
         ],
         "to": [


### PR DESCRIPTION
### Summary
SBI Online moved its login host from `onlinesbi.sbi` to `onlinesbi.sbi.bank.in`. This adds a `from`/`to` shared-credentials group so passwords saved for `onlinesbi.sbi` autofill on `onlinesbi.sbi.bank.in`.

`fromDomainsAreObsoleted` is `true` because the old host no longer serves logins; both `onlinesbi.sbi` and `www.onlinesbi.sbi` 307 to the new one. I use SBI Online first-hand.

This PR is SBI Online (`onlinesbi.sbi`) only. It does not map `sbi.co.in` or other SBI properties. Axis is #1242, Federal is #1243, BoB is #1244, IDFC is #1245. HDFC is already in the file (`hdfcbank.com` → `hdfc.bank.in`).

### Live evidence (2026-09-04 UTC)
Re-checked with `curl -sI` (and GET where HEAD is not a useful login response):

- `https://onlinesbi.sbi/` → HTTP 307 `Location: https://onlinesbi.sbi.bank.in/` (HEAD and GET)
- `https://www.onlinesbi.sbi/` → HTTP 307 `Location: https://onlinesbi.sbi.bank.in/` (HEAD and GET)
- `https://onlinesbi.sbi.bank.in/` → HEAD HTTP 404; GET HTTP 200

That is CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in).

### First-hand + archive (login migration, not bare marketing redirect)

I use SBI Online first-hand.

`onlinesbi.sbi` / `retail.onlinesbi.sbi` hosted the retail entry with a Personal Login CTA into `retail/login.htm` (userid + password flow). This is not a bare marketing redirect.

Archive (Jun 2022 retail entry — LOGIN CTA to `retail.onlinesbi.sbi/retail/login.htm`, plus prelogin copy referencing userid and password):
https://web.archive.org/web/20220625081140/https://retail.onlinesbi.sbi/

Live today: `onlinesbi.sbi` / `www.onlinesbi.sbi` → 307 `onlinesbi.sbi.bank.in`; `retail.onlinesbi.sbi` redirects into the new `.bank.in` retail stack.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 307s to `onlinesbi.sbi.bank.in`)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.