### PR TITLE
CI: run PatternRegexpToPasswordRulesConverter tests when converter changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,3 +72,40 @@ jobs:
       run: npm install -g ajv-cli
     - name: Validate JSONs against their schemas
       run: ./tools/validate-json-schemas.sh
+
+  pattern-regexp-converter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Check whether converter files changed
+      id: filter
+      run: |
+        set -eu
+        if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+          git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}"
+          range="origin/${GITHUB_BASE_REF}...HEAD"
+        elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+          range="${{ github.event.before }}...HEAD"
+        else
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "Running converter tests (no diff base available)."
+          exit 0
+        fi
+
+        echo "Diff range: $range"
+        git diff --name-only "$range" | tee /tmp/changed-files.txt
+
+        if grep -qE '^(tools/PatternRegexpToPasswordRulesConverter/|\.github/workflows/lint\.yml$)' /tmp/changed-files.txt; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "run=false" >> "$GITHUB_OUTPUT"
+          echo "Skipping converter tests; no relevant files changed."
+        fi
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      if: steps.filter.outputs.run == 'true'
+    - name: Run PatternRegexpToPasswordRulesConverter tests
+      if: steps.filter.outputs.run == 'true'
+      run: ./tools/PatternRegexpToPasswordRulesConverter/run-tests.sh


### PR DESCRIPTION
### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

Adds a Lint job that runs `tools/PatternRegexpToPasswordRulesConverter/run-tests.sh`, for #1166.

@rmondello asked on that issue that the suite **only run when the relevant JS files change**, so this is not always-on. Other Lint jobs still run on every push/PR. Converter tests run only if `tools/PatternRegexpToPasswordRulesConverter/**` or `.github/workflows/lint.yml` changed (`git diff --name-only` against the PR base / push `before` SHA). Checkout and setup-node use the same SHA pins as the rest of `lint.yml`.

This replaces closed #1193, which added the job but ran it on every Lint workflow.

I ran the suite by hand on this change:

```
$ ./tools/PatternRegexpToPasswordRulesConverter/run-tests.sh
...
All 59 tests passed.
```
