### PR TITLE
Share credentials from requestio.tech to alma-vip.com

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -847,6 +847,14 @@
         ]
     },
     {
+        "from": [
+            "requestio.tech"
+        ],
+        "to": [
+            "alma-vip.com"
+        ]
+    },
+    {
         "shared": [
             "s.activision.com",
             "profile.callofduty.com"


### PR DESCRIPTION
### Summary

Adds a `from`/`to` shared-credentials group so that passwords saved for `requestio.tech` autofill on `alma-vip.com`.

Both hostnames belong to the same product (AlmaVIP) and authenticate against the same user store: there is a single set of accounts and neither domain has a login of its own beyond the one described below. The split is an artefact of the deployment — `requestio.tech` serves the API and the server-rendered pages, `alma-vip.com` serves the web client — and the user-visible consequence is that **the password is created on one domain and used on the other**.

### Shared credentials evidence (live, 2026-09-04)

**The password-setting forms are on `requestio.tech`.** Both carry `<input type="password" autocomplete="new-password">`:

- `https://app.requestio.tech/reset-password?token=…` — password reset
- `https://app.requestio.tech/invite?token=…` — invitation acceptance, where a user sets their first password

**Those same pages send the user to `alma-vip.com` to sign in.** Verifiable without a valid token:

```
$ curl -s "https://app.requestio.tech/reset-password?token=x" | grep -o "https://app.alma-vip.com[^\"]*"
https://app.alma-vip.com/login
https://app.alma-vip.com/forgot-password

$ curl -s "https://app.requestio.tech/password-reset-success" | grep -o "https://app.alma-vip.com[^\"]*"
https://app.alma-vip.com/login
```

**`https://app.requestio.tech/login` does not serve a login form.** It is an interstitial whose primary action links to `https://app.alma-vip.com/login`:

```
$ curl -s https://app.requestio.tech/login | grep -o 'href="https://app.alma-vip.com/login"'
href="https://app.alma-vip.com/login"
```

So a browser saves the credential under `requestio.tech` and then never offers it at `app.alma-vip.com/login`, which is exactly where the user is sent to use it.

**`shared` would be wrong** for the reason given in the template's own example: `requestio.tech` does not keep a login form of its own, it points to `alma-vip.com` for sign-in. Hence `from`/`to`. `fromDomainsAreObsoleted` is **not** set: `requestio.tech` is not obsolete — it is the live domain that continues to serve the password reset and invitation flows.

Both domains are operated by the same organisation, and I am submitting this on its behalf.

### Validation

```
$ ajv -s quirks/schemas/shared-credentials-schema.json -d quirks/shared-credentials.json --spec=draft2020
quirks/shared-credentials.json valid

$ ruby .github/workflows/lint-scripts/websites-shared-credentials-sort-order.rb   # no output: sorted
$ ruby .github/workflows/lint-scripts/websites-shared-credentials-duplicates.rb   # no output: no duplicates
```

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live links from the password-setting pages on `requestio.tech` to the login page on `alma-vip.com`, shown above)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.
