### PR TITLE
Add shared credentials for Canara Bank (canarabank.com → canarabank.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -208,6 +208,15 @@
     },
     {
         "from": [
+            "canarabank.com"
+        ],
+        "to": [
+            "canarabank.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
+        "from": [
             "carsensor.net"
         ],
         "to": [


### PR DESCRIPTION
### Summary
Canara Bank moved its public site from `canarabank.com` to `canarabank.bank.in`. This adds a `from`/`to` shared-credentials group so passwords saved for `canarabank.com` autofill on `canarabank.bank.in`.

`fromDomainsAreObsoleted` is `true` because the old host no longer serves the site; it 301s to the new one.

This PR is Canara only. HDFC is already in the file (`hdfcbank.com` → `hdfc.bank.in`). Other Indian bank `.bank.in` migrations are separate PRs.

### Live evidence (2026-09-06 UTC)
- `https://www.canarabank.com/` → HTTP 301 `Location: https://www.canarabank.bank.in/`
- `https://canarabank.com/` → HTTP 301 `Location: https://www.canarabank.bank.in:443/`
- `https://www.canarabank.bank.in/` → HTTP 200
- `https://canarabank.bank.in/` → HTTP 301 `Location: https://www.canarabank.bank.in/`

That is CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in).

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 301s to `canarabank.bank.in`)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.
