### PR TITLE
Add shared credentials for Bandhan Bank (bandhanbank.com → bandhan.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -179,6 +179,15 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "from": [
+            "bandhanbank.com"
+        ],
+        "to": [
+            "bandhan.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "bgg.cc",
             "boardgamegeek.com",


### PR DESCRIPTION
### Summary
Bandhan Bank moved its public site from `bandhanbank.com` to `bandhan.bank.in`. This adds a `from`/`to` shared-credentials group so passwords saved for `bandhanbank.com` autofill on `bandhan.bank.in`.

`fromDomainsAreObsoleted` is `true` because the old host no longer serves the site; it 302s to the new one.

This PR is Bandhan only.

### Live evidence (2026-09-06 UTC)
Re-checked with `curl -sI` (HEAD) and `curl -sD - -o /dev/null` (GET; same status/Location as HEAD):
- `https://www.bandhanbank.com/` → HTTP 302 `Location: https://www.bandhan.bank.in/`
- `https://bandhanbank.com/` → HTTP 302 `Location: https://bandhan.bank.in/`
- `https://www.bandhan.bank.in/` → HTTP 200
- `https://bandhan.bank.in/` → HTTP 200

That is CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in).

`./tools/validate-json-schemas.sh` — `quirks/shared-credentials.json` valid.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 302s to `bandhan.bank.in`)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.
