### PR TITLE
Add shared credentials for RBL Bank (rblbank.com → rbl.bank.in)

### DIFF
--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -828,6 +828,15 @@
         "fromDomainsAreObsoleted": true
     },
     {
+        "from": [
+            "rblbank.com"
+        ],
+        "to": [
+            "rbl.bank.in"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "redis.com",
             "redislabs.com"


### PR DESCRIPTION
### Summary
RBL Bank moved its public site from `rblbank.com` to `rbl.bank.in`. This adds a `from`/`to` shared-credentials group so passwords saved for `rblbank.com` autofill on `rbl.bank.in`.

`fromDomainsAreObsoleted` is `true` because the old host no longer serves the site; it 301s to the new one.

This PR is RBL only.

### Live evidence (2026-09-06 UTC)
Re-checked with `curl -sI` (HEAD) and `curl -sI -X GET` (GET; same status/Location as HEAD for the `from` hop):
- `https://www.rblbank.com/` → HTTP 301 `Location: https://www.rbl.bank.in:443/`
- `https://rblbank.com/` → HTTP 301 `Location: https://www.rblbank.com/`
- `https://www.rbl.bank.in/` → HTTP 200
- `https://rbl.bank.in/` → HTTP 301 `Location: https://www.rbl.bank.in/`

That is CONTRIBUTING’s `from`/`to` case (`from` domains redirect to `to` to log in).

`./tools/validate-json-schemas.sh` — `quirks/shared-credentials.json` valid.

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for shared-credentials.json
- [x] There's evidence the domains are currently related (live 301s to `rbl.bank.in`)
- [x] If using `from` and `to`, the `from` domain(s) redirect to the `to` domain to log in.
